### PR TITLE
Training datasets as list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 ## Usage
 
-We currently support MNIST, FashionMNIST, and CIFAR10 training datasets.
+Currently Scidata supports the following training datasets:
+
+- MNIST
+- FashionMNIST
+- CIFAR10
 
 Download or fetch datasets locally:
 


### PR DESCRIPTION
Update readme so supported training datasets show as a list

before: 
```
We currently support MNIST, FashionMNIST, and CIFAR10 training datasets.
```

after
```
Currently Scidata supports the following training datasets:

- MNIST
- FashionMNIST
- CIFAR10
```