### PR TITLE
Labels info

### DIFF
--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -53,7 +53,7 @@ defmodule Scidata.CIFAR10 do
   end
 
   @doc """
-  Shows names of labels of the dataset.
+  Shows descriptions of dataset labels.
 
   Label values returned by `download/1` correspond to indices in the lists
   returned here.

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -53,6 +53,48 @@ defmodule Scidata.CIFAR10 do
   end
 
   @doc """
+  Shows names of labels of the dataset.
+
+  Label values returned by `download/1` correspond to indices in the lists
+  returned here.
+
+  ## Examples
+      iex> transform_labels = fn {b, t, _} -> b |> Nx.from_binary(t) end
+      iex> {_, labels} = Scidata.CIFAR10.download(transform_labels: transform_labels)
+      {{<<59, 43, 50, 68, 98, 119, 139, 145, 149, 149, 131, 125, 142, 144, 137, 129,
+          137, 134, 124, 139, 139, 133, 136, 139, 152, 163, 168, 159, 158, 158, 152,
+          148, 16, 0, 18, 51, 88, 120, 128, 127, 126, 116, 106, 101, 105, 113, 109,
+          112, ...>>, {:u, 8}, {50000, 3, 32, 32}},
+       {<<6, 9, 9, 4, 1, 1, 2, 7, 8, 3, 4, 7, 7, 2, 9, 9, 9, 3, 2, 6, 4, 3, 6, 6, 2,
+          6, 3, 5, 4, 0, 0, 9, 1, 3, 4, 0, 3, 7, 3, 3, 5, 2, 2, 7, 1, 1, 1, ...>>,
+        {:u, 8}, {50000}}}
+      iex> label_names = Scidata.CIFAR10.labels_info()
+      ["airplane", "automobile", "bird", "cat", "deer", "dog", "frog", "horse",
+       "ship", "truck"]
+      iex> labels |> Nx.to_flat_list() |> Enum.map(fn label_index -> Enum.at(label_names, label_index) end)
+      ["frog", "truck", "truck", "deer", "automobile", "automobile", "bird", "horse",
+       "ship", "cat", "deer", "horse", "horse", "bird", "truck", "truck", "truck", ...]
+
+
+
+
+  """
+  def labels_info() do
+    files = Utils.get!(@base_url <> @dataset_file).body
+
+    labels =
+      files
+      |> Enum.find(fn {fname, _} ->
+        String.match?(List.to_string(fname), ~r/batches.meta/)
+      end)
+      |> elem(1)
+      |> String.trim_trailing()
+      |> String.split("\n")
+
+    labels
+  end
+
+  @doc """
   Downloads the CIFAR10 test dataset or fetches it locally.
 
   Accepts the same options as `download/1`.

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -75,9 +75,6 @@ defmodule Scidata.CIFAR10 do
       ["frog", "truck", "truck", "deer", "automobile", "automobile", "bird", "horse",
        "ship", "cat", "deer", "horse", "horse", "bird", "truck", "truck", "truck", ...]
 
-
-
-
   """
   def labels_info() do
     files = Utils.get!(@base_url <> @dataset_file).body

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -59,6 +59,7 @@ defmodule Scidata.CIFAR10 do
   returned here.
 
   ## Examples
+
       iex> transform_labels = fn {b, t, _} -> b |> Nx.from_binary(t) end
       iex> {_, labels} = Scidata.CIFAR10.download(transform_labels: transform_labels)
       {{<<59, 43, 50, 68, 98, 119, 139, 145, 149, 149, 131, 125, 142, 144, 137, 129,

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -69,15 +69,7 @@ defmodule Scidata.CIFAR100 do
 
   ## Examples
 
-      iex> {_, labels} = Scidata.CIFAR100.download()
-      {{<<255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-          255, 255, 255, 231, 176, 237, 255, 255, 255, 255, 255, 252, 242, 229, 195,
-          212, 182, 255, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
-          254, 254, 254, ...>>, {:u, 8}, {50000, 3, 32, 32}},
-      {<<11, 19, 15, 29, 4, 0, 14, 11, 1, 1, 5, 86, 18, 90, 3, 28, 10, 23, 11, 31, 5,
-          39, 17, 96, 2, 82, 9, 17, 10, 71, 5, 39, 18, 8, 8, 97, 16, 80, 10, 71, 16,
-          74, 17, 59, 2, 70, 5, ...>>, {:u, 8}, {50000, 2}}}
-      iex> {coarse_class_names, fine_class_names} = Scidata.CIFAR100.labels_info()
+      iex> {_coarse_class_names, _fine_class_names} = Scidata.CIFAR100.labels_info()
       {["aquatic_mammals", "fish", "flowers", "food_containers",
         "fruit_and_vegetables", "household_electrical_devices", "household_furniture",
         "insects", "large_carnivores", "large_man-made_outdoor_things",
@@ -91,44 +83,6 @@ defmodule Scidata.CIFAR100 do
         "dolphin", "elephant", "flatfish", "forest", "fox", "girl", "hamster",
         "house", "kangaroo", "keyboard", "lamp", "lawn_mower", "leopard", "lion",
         "lizard", "lobster", "man", "maple_tree", ...]}
-      iex> {labels_bin, labels_type, labels_shape} = labels
-      {<<11, 19, 15, 29, 4, 0, 14, 11, 1, 1, 5, 86, 18, 90, 3, 28, 10, 23, 11, 31, 5,
-         39, 17, 96, 2, 82, 9, 17, 10, 71, 5, 39, 18, 8, 8, 97, 16, 80, 10, 71, 16,
-         74, 17, 59, 2, 70, 5, 87, 17, ...>>, {:u, 8}, {50000, 2}}
-      iex> labels_tensor = labels_bin |> Nx.from_binary(labels_type) |> Nx.reshape(labels_shape)
-      #Nx.Tensor<
-        u8[50000][2]
-        [
-          [11, 19],
-          [15, 29],
-          [4, 0],
-          [14, 11],
-          [1, 1],
-          ...
-        ]
-      >
-      iex> coarse_labels = labels_tensor |> Nx.slice([0,0], [50000, 1]) \
-      |> Nx.reshape({50000}) |> Nx.to_flat_list() \
-      |> Enum.map(fn label_index -> Enum.at(coarse, label_index) end)
-      ["large_omnivores_and_herbivores", "reptiles", "fruit_and_vegetables", "people",
-      "fish", "household_electrical_devices", "vehicles_1", "food_containers",
-      "large_natural_outdoor_scenes", "large_omnivores_and_herbivores", ...]
-      iex> fine_labels = labels_tensor |> Nx.slice([0,1], [50000, 1]) \
-      |> Nx.reshape({50000}) |> Nx.to_flat_list \
-      |> Enum.map(fn label_index -> Enum.at(fine, label_index) end)
-      ["cattle", "dinosaur", "apple", "boy", "aquarium_fish", "telephone", "train",
-      "cup", "cloud", "elephant", "keyboard", "willow_tree", "sunflower", "castle", ...]
-      iex> Enum.zip(coarse_labels, fine_labels)
-      [
-        {"large_omnivores_and_herbivores", "cattle"},
-        {"reptiles", "dinosaur"},
-        {"fruit_and_vegetables", "apple"},
-        {"people", "boy"},
-        {"fish", "aquarium_fish"},
-        {"household_electrical_devices", "telephone"},
-        {"vehicles_1", "train"},
-        ...
-      ]
 
   """
   def labels_info() do

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -62,7 +62,7 @@ defmodule Scidata.CIFAR100 do
   end
 
   @doc """
-  Shows names of coarse and fine labels of the dataset.
+  Shows descriptions of coarse and fine labels of the dataset.
 
   Label values returned by `download/1` correspond to indices in the lists
   returned here.

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -39,13 +39,13 @@ defmodule Scidata.CIFAR100 do
   ## Examples
 
       iex> Scidata.CIFAR100.download()
-      {{<<59, 43, 50, 68, 98, 119, 139, 145, 149, 149, 131, 125, 142, 144, 137, 129,
-      137, 134, 124, 139, 139, 133, 136, 139, 152, 163, 168, 159, 158, 158, 152,
-      148, 16, 0, 18, 51, 88, 120, 128, 127, 126, 116, 106, 101, 105, 113, 109,
-      112, ...>>, {:u, 8}, {50000, 3, 32, 32}},
-      {<<6, 9, 9, 4, 1, 1, 2, 7, 8, 3, 4, 7, 7, 2, 9, 9, 9, 3, 2, 6, 4, 3, 6, 6, 2,
-          6, 3, 5, 4, 0, 0, 9, 1, 3, 4, 0, 3, 7, 3, 3, 5, 2, 2, 7, 1, 1, 1, ...>>,
-        {:u, 8}, {50000, 2}}}
+      {{<<255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+          255, 255, 255, 231, 176, 237, 255, 255, 255, 255, 255, 252, 242, 229, 195,
+          212, 182, 255, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+          254, 254, 254, ...>>, {:u, 8}, {50000, 3, 32, 32}},
+       {<<11, 19, 15, 29, 4, 0, 14, 11, 1, 1, 5, 86, 18, 90, 3, 28, 10, 23, 11, 31, 5,
+          39, 17, 96, 2, 82, 9, 17, 10, 71, 5, 39, 18, 8, 8, 97, 16, 80, 10, 71, 16,
+          74, 17, 59, 2, 70, 5, ...>>, {:u, 8}, {50000, 2}}}
 
   """
   def download(opts \\ []) do
@@ -59,6 +59,100 @@ defmodule Scidata.CIFAR100 do
   """
   def download_test(opts \\ []) do
     download_dataset(:test, opts)
+  end
+
+  @doc """
+  Shows names of coarse and fine labels of the dataset.
+
+  Label values returned by `download/1` correspond to indices in the lists
+  returned here.
+
+  ## Examples
+
+      iex> {_, labels} = Scidata.CIFAR100.download()
+      {{<<255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+          255, 255, 255, 231, 176, 237, 255, 255, 255, 255, 255, 252, 242, 229, 195,
+          212, 182, 255, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254, 254,
+          254, 254, 254, ...>>, {:u, 8}, {50000, 3, 32, 32}},
+      {<<11, 19, 15, 29, 4, 0, 14, 11, 1, 1, 5, 86, 18, 90, 3, 28, 10, 23, 11, 31, 5,
+          39, 17, 96, 2, 82, 9, 17, 10, 71, 5, 39, 18, 8, 8, 97, 16, 80, 10, 71, 16,
+          74, 17, 59, 2, 70, 5, ...>>, {:u, 8}, {50000, 2}}}
+      iex> {coarse_class_names, fine_class_names} = Scidata.CIFAR100.labels_info()
+      {["aquatic_mammals", "fish", "flowers", "food_containers",
+        "fruit_and_vegetables", "household_electrical_devices", "household_furniture",
+        "insects", "large_carnivores", "large_man-made_outdoor_things",
+        "large_natural_outdoor_scenes", "large_omnivores_and_herbivores",
+        "medium_mammals", "non-insect_invertebrates", "people", "reptiles",
+        "small_mammals", "trees", "vehicles_1", "vehicles_2"],
+      ["apple", "aquarium_fish", "baby", "bear", "beaver", "bed", "bee", "beetle",
+        "bicycle", "bottle", "bowl", "boy", "bridge", "bus", "butterfly", "camel",
+        "can", "castle", "caterpillar", "cattle", "chair", "chimpanzee", "clock",
+        "cloud", "cockroach", "couch", "crab", "crocodile", "cup", "dinosaur",
+        "dolphin", "elephant", "flatfish", "forest", "fox", "girl", "hamster",
+        "house", "kangaroo", "keyboard", "lamp", "lawn_mower", "leopard", "lion",
+        "lizard", "lobster", "man", "maple_tree", ...]}
+      iex> {labels_bin, labels_type, labels_shape} = labels
+      {<<11, 19, 15, 29, 4, 0, 14, 11, 1, 1, 5, 86, 18, 90, 3, 28, 10, 23, 11, 31, 5,
+         39, 17, 96, 2, 82, 9, 17, 10, 71, 5, 39, 18, 8, 8, 97, 16, 80, 10, 71, 16,
+         74, 17, 59, 2, 70, 5, 87, 17, ...>>, {:u, 8}, {50000, 2}}
+      iex> labels_tensor = labels_bin |> Nx.from_binary(labels_type) |> Nx.reshape(labels_shape)
+      #Nx.Tensor<
+        u8[50000][2]
+        [
+          [11, 19],
+          [15, 29],
+          [4, 0],
+          [14, 11],
+          [1, 1],
+          ...
+        ]
+      >
+      iex> coarse_labels = labels_tensor |> Nx.slice([0,0], [50000, 1]) \
+      |> Nx.reshape({50000}) |> Nx.to_flat_list() \
+      |> Enum.map(fn label_index -> Enum.at(coarse, label_index) end)
+      ["large_omnivores_and_herbivores", "reptiles", "fruit_and_vegetables", "people",
+      "fish", "household_electrical_devices", "vehicles_1", "food_containers",
+      "large_natural_outdoor_scenes", "large_omnivores_and_herbivores", ...]
+      iex> fine_labels = labels_tensor |> Nx.slice([0,1], [50000, 1]) \
+      |> Nx.reshape({50000}) |> Nx.to_flat_list \
+      |> Enum.map(fn label_index -> Enum.at(fine, label_index) end)
+      ["cattle", "dinosaur", "apple", "boy", "aquarium_fish", "telephone", "train",
+      "cup", "cloud", "elephant", "keyboard", "willow_tree", "sunflower", "castle", ...]
+      iex> Enum.zip(coarse_labels, fine_labels)
+      [
+        {"large_omnivores_and_herbivores", "cattle"},
+        {"reptiles", "dinosaur"},
+        {"fruit_and_vegetables", "apple"},
+        {"people", "boy"},
+        {"fish", "aquarium_fish"},
+        {"household_electrical_devices", "telephone"},
+        {"vehicles_1", "train"},
+        ...
+      ]
+
+  """
+  def labels_info() do
+    files = Utils.get!(@base_url <> @dataset_file).body
+
+    coarse_labels =
+      files
+      |> Enum.find(fn {fname, _} ->
+        String.match?(List.to_string(fname), ~r/coarse_label_names/)
+      end)
+      |> elem(1)
+      |> String.trim_trailing()
+      |> String.split("\n")
+
+    fine_labels =
+      files
+      |> Enum.find(fn {fname, _} ->
+        String.match?(List.to_string(fname), ~r/fine_label_names/)
+      end)
+      |> elem(1)
+      |> String.trim_trailing()
+      |> String.split("\n")
+
+    {coarse_labels, fine_labels}
   end
 
   defp parse_images(content) do

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -11,6 +11,8 @@ defmodule Scidata.FashionMNIST do
   @train_label_file "train-labels-idx1-ubyte.gz"
   @test_image_file "t10k-images-idx3-ubyte.gz"
   @test_label_file "t10k-labels-idx1-ubyte.gz"
+  @label_descriptions ~w(t_shirt/top trouser pullover dress coat sandal shirt
+                         sneaker bag ankle_boot)
 
   @doc """
   Downloads the FashionMNIST training dataset or fetches it locally.
@@ -68,6 +70,28 @@ defmodule Scidata.FashionMNIST do
     {download_images(@test_image_file, transform_images),
      download_labels(@test_label_file, transform_labels)}
   end
+
+  @doc """
+  Shows descriptions of dataset labels.
+
+  ## Examples
+      iex> transform_labels = fn {b, t, _} -> b |> Nx.from_binary(t) end
+      iex> {_, labels} = Scidata.FashionMNIST.download(transform_labels: transform_labels)
+      {{<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ...>>,
+        {:u, 8}, {60000, 28, 28}}, #Nx.Tensor<
+         u8[60000]
+         [9, 0, 0, 3, 0, 2, 7, 2, 5, 5, 0, 9, 5, 5, 7, 9, 1, 0, 6, 4, 3, 1, 4, 8, 4, 3, 0, 2,
+          4, 4, 5, 3, 6, 6, 0, 8, 5, 2, 1, 6, 6, 7, 9, 5, 9, 2, 7, 3, ...]
+      >}
+      iex> label_names = Scidata.FashionMNIST.labels_info()
+      ["t_shirt/top", "trouser", "pullover", "dress", "coat", "sandal", "shirt",
+       "sneaker", "bag", "ankle_boot"]
+      iex> labels |> Nx.to_flat_list() |> Enum.map(fn label_index -> Enum.at(label_names, label_index) end)
+      ["ankle_boot", "t_shirt/top", "t_shirt/top", "dress", "t_shirt/top", "pullover",
+       "sneaker", "pullover", "sandal", "sandal", "t_shirt/top", "ankle_boot", ...]
+  """
+  def labels_info(), do: @label_descriptions
 
   defp download_images(image_file, transform) do
     data = Utils.get!(@base_url <> image_file).body

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -75,6 +75,7 @@ defmodule Scidata.FashionMNIST do
   Shows descriptions of dataset labels.
 
   ## Examples
+
       iex> transform_labels = fn {b, t, _} -> b |> Nx.from_binary(t) end
       iex> {_, labels} = Scidata.FashionMNIST.download(transform_labels: transform_labels)
       {{<<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
Add `labels_info/0` to CIFAR100, CIFAR10, and FashionMNIST to show descriptions of dataset labels.