### PR TITLE
IMDB Reviews dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 Scidata currently supports the following training and test datasets:
 
-- MNIST
-- FashionMNIST
 - CIFAR10
 - CIFAR100
+- IMDb Reviews
+- MNIST
+- FashionMNIST
 
 Download or fetch datasets locally:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Scidata currently supports the following training and test datasets:
 
 - CIFAR10
 - CIFAR100
+- FashionMNIST
 - IMDb Reviews
 - MNIST
-- FashionMNIST
 
 Download or fetch datasets locally:
 

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -42,16 +42,12 @@ defmodule Scidata.IMDBReviews do
     files = Utils.get!(@base_url <> @dataset_file).body
 
     {inputs, labels} =
-      files
-      |> Enum.filter(fn {fname, _} ->
-        file_match?(fname, dataset_type, example_types)
-      end)
-      |> Enum.reduce(
-        {[], []},
-        fn {fname, contents}, {inputs, labels} ->
+      for {fname, contents} <- files,
+          file_match?(fname, dataset_type, example_types),
+          reduce: {[], []} do
+        {inputs, labels} ->
           {[contents | inputs], [get_label(fname) | labels]}
-        end
-      )
+      end)
 
     {transform_inputs.(inputs), transform_labels.(labels)}
   end

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -8,6 +8,12 @@ defmodule Scidata.IMDBReviews do
 
   alias Scidata.Utils
 
+  @type sentiments :: [atom]
+  @type transform_type :: atom
+  @type transform_fn :: ([binary, ...] -> any)
+  @type transform_opt :: {transform_type, transform_fn}
+  @type opts :: [transform_opt]
+
   @doc """
   Downloads the IMDB reviews training dataset or fetches it locally.
 
@@ -15,6 +21,8 @@ defmodule Scidata.IMDBReviews do
   according to each example's label: `:pos` for positive examples, `:neg` for
   negative examples, and `:unsup` for unlabeled examples.
   """
+  @spec download(sentiments, opts()) ::
+          %{review: any(), sentiment: any()}
   def download(
         example_types \\ [:pos, :neg],
         opts \\ []
@@ -28,6 +36,8 @@ defmodule Scidata.IMDBReviews do
   `example_types` is the same argument in `download/2` but excludes `:unsup`
   because all unlabeled examples are in the training set.
   """
+  @spec download_test(sentiments, opts()) ::
+          %{review: any(), sentiment: any()}
   def download_test(
         example_types \\ [:pos, :neg],
         opts \\ []
@@ -49,7 +59,7 @@ defmodule Scidata.IMDBReviews do
           {[contents | inputs], [get_label(fname) | labels]}
       end
 
-    {transform_inputs.(inputs), transform_labels.(labels)}
+    %{review: transform_inputs.(inputs), sentiment: transform_labels.(labels)}
   end
 
   defp file_match?(fname, dataset_type, example_types) do

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -1,9 +1,20 @@
 defmodule Scidata.IMDBReviews do
+  @moduledoc """
+  Module for downloading the [Large Movie Review Dataset](https://ai.stanford.edu/~amaas/data/sentiment/).
+  """
+
   @base_url "http://ai.stanford.edu/~amaas/data/sentiment/"
   @dataset_file "aclImdb_v1.tar.gz"
 
   alias Scidata.Utils
 
+  @doc """
+  Downloads the IMDB reviews training dataset or fetches it locally.
+
+  `example_types` specifies which examples in the dataset should be returned
+  according to each example's label: `:pos` for positive examples, `:neg` for
+  negative examples, and `:unsup` for unlabeled examples.
+  """
   def download(
         example_types \\ [:pos, :neg],
         opts \\ []
@@ -11,6 +22,12 @@ defmodule Scidata.IMDBReviews do
     download_dataset(example_types, :train, opts)
   end
 
+  @doc """
+  Downloads the IMDB reviews test dataset or fetches it locally.
+
+  `example_types` is the same argument in `download/2` but excludes `:unsup`
+  because all unlabeled examples are in the training set.
+  """
   def download_test(
         example_types \\ [:pos, :neg],
         opts \\ []

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -8,11 +8,12 @@ defmodule Scidata.IMDBReviews do
 
   alias Scidata.Utils
 
-  @type sentiments :: [atom]
-  @type transform_type :: atom
-  @type transform_fn :: ([binary, ...] -> any)
-  @type transform_opt :: {transform_type, transform_fn}
-  @type opts :: [transform_opt]
+  @type train_sentiment :: :pos | :neg | :unsup
+  @type test_sentiment :: :pos | :neg
+  @type opts :: [
+          transform_inputs: ([binary, ...] -> any),
+          transform_labels: ([integer, ...] -> any)
+        ]
 
   @doc """
   Downloads the IMDB reviews training dataset or fetches it locally.
@@ -21,8 +22,7 @@ defmodule Scidata.IMDBReviews do
   according to each example's label: `:pos` for positive examples, `:neg` for
   negative examples, and `:unsup` for unlabeled examples.
   """
-  @spec download(sentiments, opts()) ::
-          %{review: any(), sentiment: any()}
+  @spec download([train_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | -1}
   def download(
         example_types \\ [:pos, :neg],
         opts \\ []
@@ -36,8 +36,7 @@ defmodule Scidata.IMDBReviews do
   `example_types` is the same argument in `download/2` but excludes `:unsup`
   because all unlabeled examples are in the training set.
   """
-  @spec download_test(sentiments, opts()) ::
-          %{review: any(), sentiment: any()}
+  @spec download_test([test_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | -1}
   def download_test(
         example_types \\ [:pos, :neg],
         opts \\ []

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -47,7 +47,7 @@ defmodule Scidata.IMDBReviews do
           reduce: {[], []} do
         {inputs, labels} ->
           {[contents | inputs], [get_label(fname) | labels]}
-      end)
+      end
 
     {transform_inputs.(inputs), transform_labels.(labels)}
   end

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -49,21 +49,17 @@ defmodule Scidata.IMDBReviews do
     transform_labels = opts[:transform_labels] || (& &1)
 
     files = Utils.get!(@base_url <> @dataset_file).body
+    regex = ~r"#{dataset_type}/(#{Enum.join(example_types, "|")})/"
 
     {inputs, labels} =
       for {fname, contents} <- files,
-          file_match?(fname, dataset_type, example_types),
+          List.to_string(fname) =~ regex,
           reduce: {[], []} do
         {inputs, labels} ->
           {[contents | inputs], [get_label(fname) | labels]}
       end
 
     %{review: transform_inputs.(inputs), sentiment: transform_labels.(labels)}
-  end
-
-  defp file_match?(fname, dataset_type, example_types) do
-    pattern = ~r/#{dataset_type}\/(#{Enum.join(example_types, "|")})\//
-    String.match?(List.to_string(fname), pattern)
   end
 
   defp get_label(fname) do

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -22,13 +22,8 @@ defmodule Scidata.IMDBReviews do
   according to each example's label: `:pos` for positive examples, `:neg` for
   negative examples, and `:unsup` for unlabeled examples.
   """
-  @spec download([example_types: train_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | 0}
-  def download(
-        example_types \\ [:pos, :neg],
-        opts \\ []
-      ) do
-    download_dataset(example_types, :train, opts)
-  end
+  @spec download(example_types: [test_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | 0}
+  def download(opts \\ []), do: download_dataset(:train, opts)
 
   @doc """
   Downloads the IMDB reviews test dataset or fetches it locally.
@@ -36,15 +31,14 @@ defmodule Scidata.IMDBReviews do
   `example_types` is the same argument in `download/2` but excludes `:unsup`
   because all unlabeled examples are in the training set.
   """
-  @spec download_test([test_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | 0}
-  def download_test(
-        example_types \\ [:pos, :neg],
-        opts \\ []
-      ) do
-    download_dataset(example_types, :test, opts)
-  end
+  @spec download_test(example_types: [test_sentiment]) :: %{
+          review: [binary(), ...],
+          sentiment: 1 | 0
+        }
+  def download_test(opts \\ []), do: download_dataset(:test, opts)
 
-  defp download_dataset(example_types, dataset_type, opts) do
+  defp download_dataset(dataset_type, opts) do
+    example_types = opts[:example_types] || [:pos, :neg]
     transform_inputs = opts[:transform_inputs] || (& &1)
     transform_labels = opts[:transform_labels] || (& &1)
 

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -1,0 +1,51 @@
+defmodule Scidata.IMDBReviews do
+  @base_url "http://ai.stanford.edu/~amaas/data/sentiment/"
+  @dataset_file "aclImdb_v1.tar.gz"
+
+  alias Scidata.Utils
+
+  def download(opts \\ []) do
+    download_dataset(:train, opts)
+  end
+
+  def download_test(opts \\ []) do
+    download_dataset(:test, opts)
+  end
+
+  defp download_dataset(dataset_type, opts) do
+    transform_inputs = opts[:transform_inputs] || (& &1)
+    transform_labels = opts[:transform_labels] || (& &1)
+
+    files = Utils.get!(@base_url <> @dataset_file).body
+
+    pos_files =
+      Enum.filter(files, fn {fname, _} ->
+        file_match?(fname, dataset_type, :pos)
+      end)
+
+    neg_files =
+      Enum.filter(files, fn {fname, _} ->
+        file_match?(fname, dataset_type, :neg)
+      end)
+
+    :rand.seed(:exsss, {101, 102, 103})
+
+    {inputs, labels} =
+      pos_files
+      |> Enum.zip(Stream.repeatedly(fn -> 1 end))
+      |> Enum.concat(Enum.zip(neg_files, Stream.repeatedly(fn -> 0 end)))
+      |> Enum.shuffle()
+      |> Enum.reduce(
+        {[], []},
+        fn {{_fname, contents}, label}, {inputs, labels} ->
+          {[contents | inputs], [label | labels]}
+        end
+      )
+
+    {transform_inputs.(inputs), transform_labels.(labels)}
+  end
+
+  defp file_match?(fname, dataset_type, label_type) do
+    String.match?(List.to_string(fname), ~r/#{dataset_type}\/#{label_type}/)
+  end
+end

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -22,7 +22,7 @@ defmodule Scidata.IMDBReviews do
   according to each example's label: `:pos` for positive examples, `:neg` for
   negative examples, and `:unsup` for unlabeled examples.
   """
-  @spec download([train_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | -1}
+  @spec download([example_types: train_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | 0}
   def download(
         example_types \\ [:pos, :neg],
         opts \\ []
@@ -36,7 +36,7 @@ defmodule Scidata.IMDBReviews do
   `example_types` is the same argument in `download/2` but excludes `:unsup`
   because all unlabeled examples are in the training set.
   """
-  @spec download_test([test_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | -1}
+  @spec download_test([test_sentiment]) :: %{review: [binary(), ...], sentiment: 1 | 0}
   def download_test(
         example_types \\ [:pos, :neg],
         opts \\ []
@@ -67,7 +67,7 @@ defmodule Scidata.IMDBReviews do
 
     cond do
       fname =~ "pos" -> 1
-      fname =~ "neg" -> -1
+      fname =~ "neg" -> 0
       fname =~ "unsup" -> nil
     end
   end

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -63,10 +63,12 @@ defmodule Scidata.IMDBReviews do
   end
 
   defp get_label(fname) do
+    fname = List.to_string(fname)
+
     cond do
-      String.match?(List.to_string(fname), ~r/pos/) -> 1
-      String.match?(List.to_string(fname), ~r/neg/) -> 0
-      String.match?(List.to_string(fname), ~r/unsup/) -> nil
+      fname =~ "pos" -> 1
+      fname =~ "neg" -> -1
+      fname =~ "unsup" -> nil
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Scidata.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @repo_url "https://github.com/elixir-nx/scidata"
 
   def project do

--- a/test/imdb_reviews_test.exs
+++ b/test/imdb_reviews_test.exs
@@ -1,0 +1,17 @@
+defmodule IMDBReviewsTest do
+  use ExUnit.Case
+
+  describe "download" do
+    test "retrieves training set" do
+      {train_inputs, train_targets} = Scidata.IMDBReviews.download([:pos, :neg, :unsup])
+      assert length(train_inputs) == 75000
+      assert length(train_targets) == 75000
+    end
+
+    test "retrieves test set" do
+      {test_inputs, test_targets} = Scidata.IMDBReviews.download_test([:pos, :neg])
+      assert length(test_inputs) == 25000
+      assert length(test_targets) == 25000
+    end
+  end
+end

--- a/test/imdb_reviews_test.exs
+++ b/test/imdb_reviews_test.exs
@@ -6,7 +6,19 @@ defmodule IMDBReviewsTest do
   describe "download" do
     test "retrieves training set" do
       %{review: train_inputs, sentiment: train_targets} =
-        Scidata.IMDBReviews.download([:pos, :neg, :unsup])
+        Scidata.IMDBReviews.download()
+
+      assert length(train_inputs) == 25000
+      assert length(train_targets) == 25000
+
+      %{review: train_inputs, sentiment: train_targets} =
+        Scidata.IMDBReviews.download(example_types: [:pos, :neg])
+
+      assert length(train_inputs) == 25000
+      assert length(train_targets) == 25000
+
+      %{review: train_inputs, sentiment: train_targets} =
+        Scidata.IMDBReviews.download(example_types: [:pos, :neg, :unsup])
 
       assert length(train_inputs) == 75000
       assert length(train_targets) == 75000
@@ -14,18 +26,18 @@ defmodule IMDBReviewsTest do
 
     test "retrieves test set" do
       %{review: test_inputs, sentiment: test_targets} =
-        Scidata.IMDBReviews.download_test([:pos, :neg])
+        Scidata.IMDBReviews.download_test(example_types: [:pos, :neg])
 
       assert length(test_inputs) == 25000
       assert length(test_targets) == 25000
-      assert [-1, -1, -1, -1, -1] = Enum.take(train_targets, -5)
+      assert [0, 0, 0, 0, 0] = Enum.take(test_targets, -5)
     end
 
-    test "utilizes sentiment and opts args" do
+    test "utilizes transform opts" do
       clip = fn inputs -> Enum.map(inputs, &String.slice(&1, 0..20)) end
 
       %{review: reviews, sentiment: targets} =
-        Scidata.IMDBReviews.download([:pos], transform_inputs: clip)
+        Scidata.IMDBReviews.download(example_types: [:pos], transform_inputs: clip)
 
       assert Enum.take(reviews, 10) == [
                "The story centers aro",

--- a/test/imdb_reviews_test.exs
+++ b/test/imdb_reviews_test.exs
@@ -18,6 +18,7 @@ defmodule IMDBReviewsTest do
 
       assert length(test_inputs) == 25000
       assert length(test_targets) == 25000
+      assert [-1, -1, -1, -1, -1] = Enum.take(train_targets, -5)
     end
 
     test "utilizes sentiment and opts args" do

--- a/test/imdb_reviews_test.exs
+++ b/test/imdb_reviews_test.exs
@@ -1,17 +1,45 @@
 defmodule IMDBReviewsTest do
   use ExUnit.Case
 
+  @moduletag timeout: 120_000
+
   describe "download" do
     test "retrieves training set" do
-      {train_inputs, train_targets} = Scidata.IMDBReviews.download([:pos, :neg, :unsup])
+      %{review: train_inputs, sentiment: train_targets} =
+        Scidata.IMDBReviews.download([:pos, :neg, :unsup])
+
       assert length(train_inputs) == 75000
       assert length(train_targets) == 75000
     end
 
     test "retrieves test set" do
-      {test_inputs, test_targets} = Scidata.IMDBReviews.download_test([:pos, :neg])
+      %{review: test_inputs, sentiment: test_targets} =
+        Scidata.IMDBReviews.download_test([:pos, :neg])
+
       assert length(test_inputs) == 25000
       assert length(test_targets) == 25000
+    end
+
+    test "utilizes sentiment and opts args" do
+      clip = fn inputs -> Enum.map(inputs, &String.slice(&1, 0..20)) end
+
+      %{review: reviews, sentiment: targets} =
+        Scidata.IMDBReviews.download([:pos], transform_inputs: clip)
+
+      assert Enum.take(reviews, 10) == [
+               "The story centers aro",
+               "'The Adventures Of Ba",
+               "This film and it's se",
+               "I love this movie lik",
+               "A hit at the time but",
+               "Very smart, sometimes",
+               "With the mixed review",
+               "This movie really kic",
+               "I'd always wanted Dav",
+               "Like I said its a hid"
+             ]
+
+      assert Enum.take(targets, 10) == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
     end
   end
 end


### PR DESCRIPTION
These changes add training and test sets for the [IMDB reviews dataset](http://ai.stanford.edu/~amaas/data/sentiment/) related to #11. Train and test sets each contain 25000 labeled examples; each example includes a textual review of a movie and a binary label categorizing the example as having positive sentiment (1) or negative sentiment (0).

The dataset can be queried like:

```elixir
{inputs, targets} = Scidata.IMDBReviews.download
{test_inputs, test_targets} = Scidata.IMDBReviews.download_test
```

### Questions and Discussion
-  The source dataset also includes 50000 unlabeled examples useful for unsupervised learning. Do we want to add that set to the API as well?
- The return tuple for `download/1` and `download_test/1` is two lists, but we could return raw binaries instead (where inputs might be separated by newline character). 
- We don't provide a type or a shape for the return values--there's no tensor type associated with the data, and the "shape" of each example input is variable because reviews have variable length. Is there type that seems sensible to provide in the return tuple? The shape we might specify as `{25000, nil}` for inputs and `{25000}` for labels.
- We could make return labels and datasets as streams for faster initial load and to avoid keeping it in memory, but the dataset is not massive so I'm unsure if it's worth it.
- It seems some codepoints aren't UTF-8 encoded and thus not "printable". This leads to some examples like
```elixir
[..., 
   "...The BBC version is so superior it's not even funny and everything about this version is an insult to its memory. In short if you must see it be sure you have read the book first or seen the BBC version other wise you will be lead done the deluded road that this is what it's like, which its not!",
   <<75, 97, 122, 117, 111, 32, 75, 111, 109, 105, 122, 117, 32, 115, 116, 114,
     105, 107, 101, 115, 32, 97, 103, 97, 105, 110, 32, 119, 105, 116, 104, 32,
     34, 69, 110, 116, 114, 97, 105, 108, 115, ...>>,
   "Daniel Percival's \"Dirty War\", a BBC production made for television was shown recently on cable. The film has a documentary style in the way it goes after the people that caused the near holocaust in one of the big metropolis of the world, London...",
...]
```
We probably don't need to address this—users can clean and tokenize bitstrings of each entry as desired—but I wanted to flag. The experience on [TFDS](https://www.tensorflow.org/datasets/catalog/imdb_reviews) is similar.