### PR TITLE
Added basic dataset (SQuAD)

### DIFF
--- a/examples/squad_explorer.exs
+++ b/examples/squad_explorer.exs
@@ -1,0 +1,16 @@
+Mix.install([
+  {:explorer, "~> 0.1.0-dev", github: "elixir-nx/explorer", branch: "main"},
+  {:scidata, "~> 0.1.3"}
+])
+
+entries = Scidata.Squad.download()
+tables = Scidata.Squad.to_maps(entries)
+{titles, contexts, qas} = tables
+
+qa_df = Explorer.DataFrame.from_map(qas)
+
+titles_df = Explorer.DataFrame.from_map(titles)
+contexts_df = Explorer.DataFrame.from_map(contexts)
+tc_df = Explorer.DataFrame.join(titles_df, contexts_df)
+
+squad_df = Explorer.DataFrame.join(tc_df, qa_df)

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -7,7 +7,8 @@ defmodule Scidata.Squad do
   alias Scidata.Utils
 
   @base_url "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
-  @dataset_file "train-v1.1.json"
+  @train_dataset_file "train-v1.1.json"
+  @test_dataset_file "dev-v1.1.json"
 
   @doc """
   Downloads the SQuAD dataset.
@@ -38,12 +39,16 @@ defmodule Scidata.Squad do
   """
 
   def download() do
-    download_dataset()
+    download_dataset(@train_dataset_file)
   end
 
-  defp download_dataset() do
+  def download_test() do
+    download_dataset(@test_dataset_file)
+  end
+
+  defp download_dataset(dataset_name) do
     content =
-      Utils.get!(@base_url <> @dataset_file).body
+      Utils.get!(@base_url <> dataset_name).body
       |> Jason.decode!()
 
     content["data"]

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -82,7 +82,8 @@ defmodule Scidata.Squad do
   Converts the squad dataset to a tuple containing three maps.
 
   ## Examples
-    iex> Scidata.Squad.to_maps(entries)
+
+      iex> Scidata.Squad.to_maps(entries)
       {
         %{
           title: ["University_of_Notre_Dame", "Beyoncé", ...],

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -93,7 +93,7 @@ defmodule Scidata.Squad do
     |> Enum.reduce(%{}, fn {k, v}, acc -> Map.put(acc, k, :lists.reverse(List.flatten(v))) end)
   end
 
-  def get_join_tables(results) do
+  def to_map(dataset) do
     {titles, contexts, qas} =
       results
       |> Enum.reduce(

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -12,9 +12,7 @@ defmodule Scidata.Squad do
 
   @doc """
   Downloads the SQuAD dataset.
-
   ## Examples
-
       iex> Scidata.Squad.download()
       %{
         [
@@ -52,5 +50,123 @@ defmodule Scidata.Squad do
       |> Jason.decode!()
 
     content["data"]
+  end
+
+  def flatten(results) do
+    results
+    |> Enum.reduce(
+      %{id: [], title: [], context: [], question: [], answer: []},
+      &process_example/2
+    )
+  end
+
+  def process_example(%{"paragraphs" => paragraphs, "title" => title}, acc) do
+    paragraphs
+    |> Enum.reduce(acc, fn %{"context" => context, "qas" => qas},
+                           %{
+                             id: ids,
+                             title: titles,
+                             context: contexts,
+                             question: questions,
+                             answer: answers
+                           } ->
+      next_questions = qas |> Enum.map(& &1["question"])
+
+      next_answers =
+        qas |> Enum.map(&(&1["answers"] |> Utils.map_list_to_table(["answer_start", "text"])))
+
+      next_ids = qas |> Enum.map(& &1["id"])
+
+      next_contexts = Stream.repeatedly(fn -> context end) |> Enum.take(length(next_questions))
+      next_titles = Stream.repeatedly(fn -> title end) |> Enum.take(length(next_questions))
+
+      %{
+        id: [next_ids | ids],
+        title: [next_titles | titles],
+        context: [next_contexts | contexts],
+        question: [next_questions | questions],
+        answer: [next_answers | answers]
+      }
+    end)
+    |> Enum.reduce(%{}, fn {k, v}, acc -> Map.put(acc, k, :lists.reverse(List.flatten(v))) end)
+  end
+
+  def get_join_tables(results) do
+    results
+    |> Enum.reduce(
+      {
+        %{title: [], title_id: []},
+        %{context: [], context_id: [], title_id: []},
+        %{
+          context_id: [],
+          question_id: [],
+          question: [],
+          answer: []
+        }
+      },
+      &to_tables/2
+    )
+  end
+
+  defp to_tables(%{"paragraphs" => paragraphs, "title" => title}, acc) do
+    {title_acc, context_acc, qa_acc} = acc
+
+    %{title: titles, title_id: title_ids} = title_acc
+
+    next_title_id = length(titles) + 1
+
+    next_titles = %{
+      title_acc
+      | title: titles ++ [title],
+        title_id: title_ids ++ [next_title_id]
+    }
+
+    {next_contexts, next_qas} =
+      paragraphs
+      |> Enum.reduce(
+        {context_acc, qa_acc},
+        fn %{"context" => context, "qas" => qas},
+           {
+             %{
+               context: contexts,
+               context_id: context_ids,
+               title_id: title_ids
+             } = curr_context_acc,
+             %{
+               answer: answers,
+               context_id: foreign_context_ids,
+               question: questions,
+               question_id: question_ids
+             } = curr_qa_acc
+           } ->
+          next_context_id = length(contexts) + 1
+
+          next_questions = qas |> Enum.map(& &1["question"])
+          next_answers = qas |> Enum.map(& &1["answers"])
+          next_ids = qas |> Enum.map(& &1["id"])
+
+          next_context_acc = %{
+            curr_context_acc
+            | context: contexts ++ [context],
+              context_id: context_ids ++ [next_context_id],
+              title_id: title_ids ++ [next_title_id]
+          }
+
+          next_qa_acc = %{
+            curr_qa_acc
+            | answer: answers ++ next_answers,
+              context_id:
+                foreign_context_ids ++
+                  (Stream.repeatedly(fn -> next_context_id end)
+                   |> Enum.take(length(next_questions))),
+              question: questions ++ next_questions,
+              question_id: question_ids ++ next_ids
+          }
+
+          {next_context_acc, next_qa_acc}
+        end
+      )
+
+    {next_titles, next_contexts, next_qas}
   end
 end

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -175,8 +175,7 @@ defmodule Scidata.Squad do
           }
 
           next_foreign_context_ids =
-            Stream.repeatedly(fn -> next_context_id end)
-            |> Enum.take(length(next_questions))
+            List.duplicate(next_context_id, length(next_questions))
 
           next_qa_acc = %{
             curr_qa_acc

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -79,8 +79,8 @@ defmodule Scidata.Squad do
 
       next_ids = qas |> Enum.map(& &1["id"])
 
-      next_contexts = Stream.repeatedly(fn -> context end) |> Enum.take(length(next_questions))
-      next_titles = Stream.repeatedly(fn -> title end) |> Enum.take(length(next_questions))
+      next_contexts = List.duplicate(context, length(next_questions))
+      next_titles = List.duplicate(title, length(next_questions))
 
       %{
         id: [next_ids | ids],

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -1,6 +1,6 @@
 defmodule Scidata.Squad do
   @moduledoc """
-  Module for downloading the [Squad dataset](https://rajpurkar.github.io/SQuAD-explorer).
+  Module for downloading the [SQuAD1.1 dataset](https://rajpurkar.github.io/SQuAD-explorer).
   """
 
   require Scidata.Utils

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -12,7 +12,9 @@ defmodule Scidata.Squad do
 
   @doc """
   Downloads the SQuAD dataset.
+
   ## Examples
+
       iex> Scidata.Squad.download()
       %{
         [

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -79,11 +79,11 @@ defmodule Scidata.Squad do
   end
 
   @doc """
-  Convert a list of maps into a single map with containing list-type values.
+  Convert result of `download/0` or `download_test/0` to map for use with `Explorer.DataFrame`.
 
   ## Examples
 
-      iex> Scidata.Squad.to_columns(entries)
+      iex> columns_for_df = Scidata.Squad.download() |> Scidata.Squad.to_columns()
       %{
         "answer_start" => [515, ...],
         "context" => ["Architecturally, the...", ...],
@@ -92,7 +92,11 @@ defmodule Scidata.Squad do
         "answer_text" => ["Saint Bernadette Soubirous", ...],
         "title" => ["University_of_Notre_Dame", ...]
       }
-
+      iex> Explorer.DataFrame.from_map(columns_for_df)
+      #Explorer.DataFrame<
+      [rows: 87599, columns: 6]
+      ...
+      >
   """
 
   def to_columns(entries) do

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -9,18 +9,6 @@ defmodule Scidata.Squad do
   @base_url "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
   @dataset_file "train-v1.1.json"
 
-  @title "SQuAD: 100,000+ Questions for Machine Comprehension of Text"
-  @author "Pranav Rajpurkar, Jian Zhang, Konstantin Lopyrev, Percy Liang"
-  @year "2016"
-  @month "November"
-
-  @description """
-  Stanford Question Answering Dataset (SQuAD) is a reading comprehension
-  dataset, consisting of questions posed by crowdworkers on a set of Wikipedia
-  articles, where the answer to every question is a segment of text, or span,
-  from the corresponding reading passage, or the question might be unanswerable.
-  """
-
   @doc """
   Downloads the SQuAD dataset.
 
@@ -48,17 +36,6 @@ defmodule Scidata.Squad do
         ]
       }
   """
-  def info do
-    %{
-      "article" => %{
-        "title" => @title,
-        "author" => @author,
-        "year" => @year,
-        "month" => @month
-      },
-      "description" => @description
-    }
-  end
 
   def download() do
     download_dataset()

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -1,0 +1,74 @@
+defmodule Scidata.Squad do
+  @moduledoc """
+  Module for downloading the [Squad dataset](https://rajpurkar.github.io/SQuAD-explorer).
+  """
+
+  require Scidata.Utils
+  alias Scidata.Utils
+
+  @base_url "https://rajpurkar.github.io/SQuAD-explorer/dataset/"
+  @dataset_file "train-v1.1.json"
+
+  @title "SQuAD: 100,000+ Questions for Machine Comprehension of Text"
+  @author "Pranav Rajpurkar, Jian Zhang, Konstantin Lopyrev, Percy Liang"
+  @year "2016"
+  @month "November"
+
+  @description """
+  Stanford Question Answering Dataset (SQuAD) is a reading comprehension
+  dataset, consisting of questions posed by crowdworkers on a set of Wikipedia
+  articles, where the answer to every question is a segment of text, or span,
+  from the corresponding reading passage, or the question might be unanswerable.
+  """
+
+  @doc """
+  Downloads the SQuAD dataset.
+
+  ## Examples
+
+      iex> Scidata.Squad.download()
+      %{
+        [
+          %{
+            "paragraphs" => [
+              %{
+                "context" => "In many cities along the North American...",
+                "qas" => [
+                  %{
+                    "answers" => [%{"answer_start" => 324, "text" => "hundreds"}],
+                    "id" => "56d8a0ddbfea0914004b7706",
+                    "question" => "How many people protested on the San Francisco torch route?"
+                  },
+                  ...
+                ]
+              }
+              ...
+            ]
+          }
+        ]
+      }
+  """
+  def info do
+    %{
+      "article" => %{
+        "title" => @title,
+        "author" => @author,
+        "year" => @year,
+        "month" => @month
+      },
+      "description" => @description
+    }
+  end
+
+  def download() do
+    download_dataset()
+  end
+
+  defp download_dataset() do
+    content =
+      Utils.get!(@base_url <> @dataset_file).body
+      |> Jason.decode!()
+
+    content["data"]
+  end
+end

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -114,7 +114,7 @@ defmodule Scidata.Squad do
     {reverse_and_flatten(titles), reverse_and_flatten(contexts), reverse_and_flatten(qas)}
   end
 
-  defp to_tables(%{"paragraphs" => paragraphs, "title" => title}, acc) do
+  defp add_example(%{"paragraphs" => paragraphs, "title" => title}, acc) do
     {title_acc, context_acc, qa_acc} = acc
 
     %{title: titles, title_id: title_ids} = title_acc

--- a/lib/scidata/utils.ex
+++ b/lib/scidata/utils.ex
@@ -90,4 +90,32 @@ defmodule Scidata.Utils do
     path = Enum.join([uri.host, String.replace(uri.path, "/", "-")], "-")
     Path.join(System.tmp_dir!(), path)
   end
+
+  def map_list_to_table(list, keys) do
+    keys
+    |> Enum.map(&{&1, []})
+    |> Enum.into(%{})
+    |> to_table(list)
+  end
+
+  defp to_table(acc, []), do: acc
+
+  defp to_table(acc, [head | tail]) do
+    acc
+    |> map_to_table(head)
+    |> to_table(tail)
+  end
+
+  defp map_to_table(acc, map) do
+    map
+    |> Enum.map(fn {key, value} ->
+      current_value = acc[key]
+
+      new_value = value
+      list = current_value ++ [new_value]
+
+      {key, list}
+    end)
+    |> Enum.into(%{})
+  end
 end

--- a/lib/scidata/utils.ex
+++ b/lib/scidata/utils.ex
@@ -109,10 +109,8 @@ defmodule Scidata.Utils do
   defp map_to_table(acc, map) do
     map
     |> Enum.map(fn {key, value} ->
-      current_value = acc[key]
-
-      new_value = value
-      list = current_value ++ [new_value]
+      acc_value = acc[key]
+      list = acc_value ++ [value]
 
       {key, list}
     end)

--- a/lib/scidata/utils.ex
+++ b/lib/scidata/utils.ex
@@ -90,30 +90,4 @@ defmodule Scidata.Utils do
     path = Enum.join([uri.host, String.replace(uri.path, "/", "-")], "-")
     Path.join(System.tmp_dir!(), path)
   end
-
-  def map_list_to_table(list, keys) do
-    keys
-    |> Enum.map(&{&1, []})
-    |> Enum.into(%{})
-    |> to_table(list)
-  end
-
-  defp to_table(acc, []), do: acc
-
-  defp to_table(acc, [head | tail]) do
-    acc
-    |> map_to_table(head)
-    |> to_table(tail)
-  end
-
-  defp map_to_table(acc, map) do
-    map
-    |> Enum.map(fn {key, value} ->
-      acc_value = acc[key]
-      list = acc_value ++ [value]
-
-      {key, list}
-    end)
-    |> Enum.into(%{})
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule Scidata.MixProject do
 
   defp deps do
     [
-      {:ex_doc, ">= 0.24.0", only: :dev, runtime: false}
+      {:ex_doc, ">= 0.24.0", only: :dev, runtime: false},
+      {:jason, "~> 1.0"}
     ]
   end
 

--- a/test/squad_test.exs
+++ b/test/squad_test.exs
@@ -3,7 +3,7 @@ defmodule SquadTest do
 
   @moduletag timeout: 120_000
 
-  describe "download" do
+  describe "download/0" do
     test "retrieves training set" do
       examples = Scidata.Squad.download()
 
@@ -18,7 +18,9 @@ defmodule SquadTest do
       assert last_example["title"] == "Kathmandu"
       assert length(last_example["paragraphs"]) == 58
     end
+  end
 
+  describe "download_test/0" do
     test "retrieves test set" do
       examples = Scidata.Squad.download_test()
 
@@ -32,6 +34,25 @@ defmodule SquadTest do
 
       assert last_example["title"] == "Force"
       assert length(last_example["paragraphs"]) == 44
+    end
+  end
+
+  describe "to_columns/1" do
+    test "returns full map for each dataset" do
+      train_map = Scidata.Squad.download() |> Scidata.Squad.to_columns()
+
+      assert train_map |> Map.keys() |> Enum.sort() == [
+               "answer_start",
+               "answer_text",
+               "context",
+               "id",
+               "question",
+               "title"
+             ]
+
+      Enum.each(train_map, fn {_k, entries} ->
+        assert length(entries) == 87599
+      end)
     end
   end
 end

--- a/test/squad_test.exs
+++ b/test/squad_test.exs
@@ -1,0 +1,37 @@
+defmodule SquadTest do
+  use ExUnit.Case
+
+  @moduletag timeout: 120_000
+
+  describe "download" do
+    test "retrieves training set" do
+      examples = Scidata.Squad.download()
+
+      assert length(examples) == 442
+
+      first_example = hd(examples)
+      last_example = List.last(examples)
+
+      assert first_example["title"] == "University_of_Notre_Dame"
+      assert length(first_example["paragraphs"]) == 55
+
+      assert last_example["title"] == "Kathmandu"
+      assert length(last_example["paragraphs"]) == 58
+    end
+
+    test "retrieves test set" do
+      examples = Scidata.Squad.download_test()
+
+      assert length(examples) == 48
+
+      first_example = hd(examples)
+      last_example = List.last(examples)
+
+      assert first_example["title"] == "Super_Bowl_50"
+      assert length(first_example["paragraphs"]) == 54
+
+      assert last_example["title"] == "Force"
+      assert length(last_example["paragraphs"]) == 44
+    end
+  end
+end


### PR DESCRIPTION
There are several things we should consider in this pull request (: #16

Should the method to download and load the file keep the name as "download" ?
```elixir
dataset = Scidata.Squad.download()
```
for example Hugging Face uses the following pattern:
  **dataset = load_dataset('squad')**


Maybe we could use something like:

```elixir
dataset = Scidata.Squad.load_dataset()
```

which brings us to the next point, what kind of return should this method have:

Tools like Pandas, Hugging Face..., use datasets, as in the example below:

```
Dataset({
     features: ['id', 'title', 'context', 'question', 'answers'],
     num_rows: 1057
})
```

In them it is possible to have various information such as existing columns, number of records and some facilitating methods.

In the changes that I sent, the return is a simple list that is loaded as soon as it is executed, given these considerations, I believe I didn't choose the best decisions.

But I would like to discuss this further with you.