### PR TITLE
Add Kuzushiji MNIST dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Scidata currently supports the following training and test datasets:
 - FashionMNIST
 - IMDb Reviews
 - MNIST
+- Kuzushiji-MNIST(KMNIST)
 
 Download or fetch datasets locally:
 

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -1,0 +1,54 @@
+defmodule Scidata.KuzushijiMNIST do
+  @moduledoc """
+  Module for downloading the [Kuzushiji-MNIST dataset](https://github.com/rois-codh/kmnist).
+  """
+
+  alias Scidata.Utils
+
+  @base_url "http://codh.rois.ac.jp/kmnist/dataset/kmnist/"
+  @train_image_file "train-images-idx3-ubyte.gz"
+  @train_label_file "train-labels-idx1-ubyte.gz"
+  @test_image_file "t10k-images-idx3-ubyte.gz"
+  @test_label_file "t10k-labels-idx1-ubyte.gz"
+
+  @doc """
+  Downloads the Kuzushiji MNIST training dataset or fetches it locally.
+
+  Returns a tuple of format:
+
+      {{images_binary, images_type, images_shape},
+       {labels_binary, labels_type, labels_shape}}
+
+  If you want to one-hot encode the labels, you can:
+
+      labels_binary
+      |> Nx.from_binary(labels_type)
+      |> Nx.new_axis(-1)
+      |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
+
+  """
+  def download() do
+    {download_images(@train_image_file), download_labels(@train_label_file)}
+  end
+
+  @doc """
+  Downloads the Kuzushiji MNIST test dataset or fetches it locally.
+
+  Accepts the same options as `download/1`.
+  """
+  def download_test() do
+    {download_images(@test_image_file), download_labels(@test_label_file)}
+  end
+
+  defp download_images(image_file) do
+    data = Utils.get!(@base_url <> image_file).body
+    <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
+    {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
+  end
+
+  defp download_labels(label_file) do
+    data = Utils.get!(@base_url <> label_file).body
+    <<_::32, n_labels::32, labels::binary>> = data
+    {labels, {:u, 8}, {n_labels}}
+  end
+end

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -33,8 +33,6 @@ defmodule Scidata.KuzushijiMNIST do
 
   @doc """
   Downloads the Kuzushiji MNIST test dataset or fetches it locally.
-
-  Accepts the same options as `download/1`.
   """
   def download_test() do
     {download_images(@test_image_file), download_labels(@test_label_file)}

--- a/test/kuzushiji_mnist_test.exs
+++ b/test/kuzushiji_mnist_test.exs
@@ -1,0 +1,27 @@
+defmodule KuzushijiMNISTTest do
+  use ExUnit.Case
+
+  @moduletag timeout: 120_000
+
+  describe "download" do
+    test "retrieves training set" do
+      {{_images, {:u, 8}, {n_images, 1, n_rows, n_cols}}, {_labels, {:u, 8}, {n_labels}}} =
+        Scidata.KMNIST.download()
+
+      assert n_images == 60000
+      assert n_rows == 28
+      assert n_cols == 28
+      assert n_labels == 60000
+    end
+
+    test "retrieves test set" do
+      {{_images, {:u, 8}, {n_images, 1, n_rows, n_cols}}, {_labels, {:u, 8}, {n_labels}}} =
+        Scidata.KMNIST.download_test()
+
+      assert n_images == 10000
+      assert n_rows == 28
+      assert n_cols == 28
+      assert n_labels == 10000
+    end
+  end
+end

--- a/test/mnist_test.exs
+++ b/test/mnist_test.exs
@@ -1,4 +1,4 @@
-defmodule KuzushijiMNISTTest do
+defmodule MNISTTest do
   use ExUnit.Case
 
   @moduletag timeout: 120_000
@@ -6,7 +6,7 @@ defmodule KuzushijiMNISTTest do
   describe "download" do
     test "retrieves training set" do
       {{_images, {:u, 8}, {n_images, 1, n_rows, n_cols}}, {_labels, {:u, 8}, {n_labels}}} =
-        Scidata.KuzushijiMNIST.download()
+        Scidata.MNIST.download()
 
       assert n_images == 60000
       assert n_rows == 28
@@ -16,7 +16,7 @@ defmodule KuzushijiMNISTTest do
 
     test "retrieves test set" do
       {{_images, {:u, 8}, {n_images, 1, n_rows, n_cols}}, {_labels, {:u, 8}, {n_labels}}} =
-        Scidata.KuzushijiMNIST.download_test()
+        Scidata.MNIST.download_test()
 
       assert n_images == 10000
       assert n_rows == 28


### PR DESCRIPTION
Hi everyone,

Similar to my previous PR(#20), this PR aims to add support for the [Kuzushiji MNIST](https://github.com/rois-codh/kmnist) dataset, as mentioned in #11 and #16.

For the KMNIST dataset:
- The train dataset consists of 60k records, with each image having the size 28x28.
- The test dataset consists of 10k records each image having the size 28x28.
- It can be queried as follows:

```ex
{train_images, train_labels} = Scidata.KuzushijiMNIST.download
{test_images, test_labels} = Scidata.KuzushijiMNIST.download_test
```

The API is an exact copy of the `mnist.ex` file, with the only change being the URLs from which the datasets are downloaded. This PR also adds a quick unit test for the MNIST data loader.

A sample of the images present in the training dataset:

![Screenshot 2021-12-07 at 10 37 59 AM](https://user-images.githubusercontent.com/14368181/144956002-8ef693c8-f1ae-4577-a41d-9b9802a6555c.png)
![Screenshot 2021-12-07 at 10 38 45 AM](https://user-images.githubusercontent.com/14368181/144956077-ad5edc7a-a2e0-493b-8b60-95b20b812dd1.png)


Visualized using:
```ex
{{bin_images, img_type, img_size}, train_labels} = Scidata.KuzushijiMNIST.download
images = bin_images |> Nx.from_binary(img_type) |> Nx.reshape(img_size)
images[0..1] |> Nx.to_heatmap() |> IO.inspect
```

Thanks!