### PR TITLE
Update stb_image version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Scidata.MixProject do
       {:ex_doc, ">= 0.24.0", only: :dev, runtime: false},
       {:nimble_csv, "~> 1.1"},
       {:jason, "~> 1.0"},
-      {:stb_image, "~> 0.1.0", github: "cocoa-xu/stb_image", optional: true}
+      {:stb_image, "~> 0.1.2", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -8,5 +8,5 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_csv": {:hex, :nimble_csv, "1.1.0", "b1dba4a86be9e03065c9de829050468e591f569100332db949e7ce71be0afc25", [:mix], [], "hexpm", "e986755bc302832cac429be6deda0fc9d82d3c82b47abefb68b3c17c9d949a3f"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
-  "stb_image": {:git, "https://github.com/cocoa-xu/stb_image.git", "64a70d05a3457ce22598dcb8aa8f204e1f127822", []},
+  "stb_image": {:hex, :stb_image, "0.1.2", "f6b02bb1add782b6bf7a5278d7d2a15c96ab3c92f639555be5ce99643b2a3536", [:make, :mix], [{:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "55773080dd738a8f7c53a3a6275f7ac3702223750f092c1ef15cf7fce2498aea"},
 }


### PR DESCRIPTION
Following up on the conversation here: https://github.com/elixir-nx/scidata/pull/25#discussion_r785289951, this PR updates the `stb_image` version.

I've confirmed that this version works as expected, and the test `caltech101_test.exs` also passes.