### PR TITLE
Allow user to download dataset from custom/mirror urls

### DIFF
--- a/lib/scidata/caltech101.ex
+++ b/lib/scidata/caltech101.ex
@@ -6,7 +6,8 @@ defmodule Scidata.Caltech101 do
   require Scidata.Utils
   alias Scidata.Utils
 
-  @base_url "https://s3.amazonaws.com/fast-ai-imageclas/caltech_101.tgz"
+  @base_url "https://s3.amazonaws.com/fast-ai-imageclas/"
+  @dataset_file "caltech_101.tgz"
   @labels_shape {9144, 1}
   @label_mapping %{
     accordion: 0,
@@ -128,6 +129,13 @@ defmodule Scidata.Caltech101 do
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(1..102)))
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://s3.amazonaws.com/fast-ai-imageclas/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"caltech_101.tgz"`
+
   """
   def download(opts \\ []) do
     unless Code.ensure_loaded?(StbImage) do
@@ -139,9 +147,10 @@ defmodule Scidata.Caltech101 do
 
   defp download_dataset(_dataset_type, opts) do
     base_url = opts[:base_url] || @base_url
+    dataset_file = opts[:dataset_file] || @dataset_file
 
     # Skip first file since it's a temporary file.
-    [_ | files] = Utils.get!(base_url).body
+    [_ | files] = Utils.get!(base_url <> dataset_file).body
 
     {images, shapes, labels} =
       files

--- a/lib/scidata/caltech101.ex
+++ b/lib/scidata/caltech101.ex
@@ -132,10 +132,15 @@ defmodule Scidata.Caltech101 do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://s3.amazonaws.com/fast-ai-imageclas/"`
+
     * `:dataset_file` - Dataset filename.
+
       Defaults to `"caltech_101.tgz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/caltech101.ex
+++ b/lib/scidata/caltech101.ex
@@ -131,11 +131,11 @@ defmodule Scidata.Caltech101 do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://s3.amazonaws.com/fast-ai-imageclas/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"caltech_101.tgz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/caltech101.ex
+++ b/lib/scidata/caltech101.ex
@@ -135,6 +135,8 @@ defmodule Scidata.Caltech101 do
       Defaults to `"https://s3.amazonaws.com/fast-ai-imageclas/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"caltech_101.tgz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   def download(opts \\ []) do
@@ -150,7 +152,7 @@ defmodule Scidata.Caltech101 do
     dataset_file = opts[:dataset_file] || @dataset_file
 
     # Skip first file since it's a temporary file.
-    [_ | files] = Utils.get!(base_url <> dataset_file).body
+    [_ | files] = Utils.get!(base_url <> dataset_file, opts).body
 
     {images, shapes, labels} =
       files

--- a/lib/scidata/caltech101.ex
+++ b/lib/scidata/caltech101.ex
@@ -138,8 +138,10 @@ defmodule Scidata.Caltech101 do
   end
 
   defp download_dataset(_dataset_type, opts) do
+    base_url = opts[:base_url] || @base_url
+
     # Skip first file since it's a temporary file.
-    [_ | files] = Utils.get!(@base_url).body
+    [_ | files] = Utils.get!(base_url).body
 
     {images, shapes, labels} =
       files

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -30,11 +30,11 @@ defmodule Scidata.CIFAR10 do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://www.cs.toronto.edu/~kriz/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"cifar-10-binary.tar.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -28,6 +28,13 @@ defmodule Scidata.CIFAR10 do
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://www.cs.toronto.edu/~kriz/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"cifar-10-binary.tar.gz"`
+
   ## Examples
 
       iex> Scidata.CIFAR10.download()

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -40,8 +40,8 @@ defmodule Scidata.CIFAR10 do
         {:u, 8}, {50000}}}
 
   """
-  def download() do
-    download_dataset(:train)
+  def download(opts \\ []) do
+    download_dataset(:train, opts)
   end
 
   @doc """
@@ -49,8 +49,8 @@ defmodule Scidata.CIFAR10 do
 
   Accepts the same options as `download/1`.
   """
-  def download_test() do
-    download_dataset(:test)
+  def download_test(opts \\ []) do
+    download_dataset(:test, opts)
   end
 
   defp parse_images(content) do
@@ -64,7 +64,7 @@ defmodule Scidata.CIFAR10 do
     {Enum.reverse(images), Enum.reverse(labels)}
   end
 
-  defp download_dataset(dataset_type) do
+  defp download_dataset(dataset_type, opts) do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -34,6 +34,8 @@ defmodule Scidata.CIFAR10 do
       Defaults to `"https://www.cs.toronto.edu/~kriz/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"cifar-10-binary.tar.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   ## Examples
 
@@ -75,7 +77,7 @@ defmodule Scidata.CIFAR10 do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 
-    files = Utils.get!(base_url <> dataset_file).body
+    files = Utils.get!(base_url <> dataset_file, opts).body
 
     {images, labels} =
       files

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -65,7 +65,10 @@ defmodule Scidata.CIFAR10 do
   end
 
   defp download_dataset(dataset_type) do
-    files = Utils.get!(@base_url <> @dataset_file).body
+    base_url = opts[:base_url] || @base_url
+    dataset_file = opts[:dataset_file] || @dataset_file
+
+    files = Utils.get!(base_url <> dataset_file).body
 
     {images, labels} =
       files

--- a/lib/scidata/cifar10.ex
+++ b/lib/scidata/cifar10.ex
@@ -31,10 +31,15 @@ defmodule Scidata.CIFAR10 do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://www.cs.toronto.edu/~kriz/"`
+
     * `:dataset_file` - Dataset filename.
+
       Defaults to `"cifar-10-binary.tar.gz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -65,7 +65,10 @@ defmodule Scidata.CIFAR100 do
   end
 
   defp download_dataset(dataset_type) do
-    files = Utils.get!(@base_url <> @dataset_file).body
+    base_url = opts[:base_url] || @base_url
+    dataset_file = opts[:dataset_file] || @dataset_file
+
+    files = Utils.get!(base_url <> dataset_file).body
 
     {images, labels} =
       files

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -28,6 +28,13 @@ defmodule Scidata.CIFAR100 do
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://www.cs.toronto.edu/~kriz/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"cifar-100-binary.tar.gz"`
+
   ## Examples
 
       iex> Scidata.CIFAR100.download()

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -34,6 +34,8 @@ defmodule Scidata.CIFAR100 do
       Defaults to `"https://www.cs.toronto.edu/~kriz/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"cifar-100-binary.tar.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   ## Examples
 
@@ -75,7 +77,7 @@ defmodule Scidata.CIFAR100 do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 
-    files = Utils.get!(base_url <> dataset_file).body
+    files = Utils.get!(base_url <> dataset_file, opts).body
 
     {images, labels} =
       files

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -30,11 +30,11 @@ defmodule Scidata.CIFAR100 do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://www.cs.toronto.edu/~kriz/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"cifar-100-binary.tar.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -31,10 +31,15 @@ defmodule Scidata.CIFAR100 do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://www.cs.toronto.edu/~kriz/"`
+
     * `:dataset_file` - Dataset filename.
+
       Defaults to `"cifar-100-binary.tar.gz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/cifar100.ex
+++ b/lib/scidata/cifar100.ex
@@ -40,8 +40,8 @@ defmodule Scidata.CIFAR100 do
         {:u, 8}, {50000, 2}}}
 
   """
-  def download() do
-    download_dataset(:train)
+  def download(opts \\ []) do
+    download_dataset(:train, opts)
   end
 
   @doc """
@@ -49,8 +49,8 @@ defmodule Scidata.CIFAR100 do
 
   Accepts the same options as `download/1`.
   """
-  def download_test() do
-    download_dataset(:test)
+  def download_test(opts \\ []) do
+    download_dataset(:test, opts)
   end
 
   defp parse_images(content) do
@@ -64,7 +64,7 @@ defmodule Scidata.CIFAR100 do
     {Enum.reverse(images), Enum.reverse(labels)}
   end
 
-  defp download_dataset(dataset_type) do
+  defp download_dataset(dataset_type, opts) do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -40,25 +40,45 @@ defmodule Scidata.FashionMNIST do
         {3739854681}}}
 
   """
-  def download() do
-    {download_images(@train_image_file), download_labels(@train_label_file)}
+  def download(opts \\ []) do
+    {download_images(:train, opts), download_labels(:train, opts)}
   end
 
   @doc """
   Downloads the FashionMNIST test dataset or fetches it locally.
   """
-  def download_test() do
-    {download_images(@test_image_file), download_labels(@test_label_file)}
+  def download_test(opts \\ []) do
+    {download_images(:test, opts), download_labels(:test, opts)}
   end
 
-  defp download_images(image_file) do
-    data = Utils.get!(@base_url <> image_file).body
+  defp download_images(:train, opts) do
+    download_images(opts[:train_image_file] || @train_image_file)
+  end
+
+  defp download_images(:test, opts) do
+    download_images(opts[:test_image_file] || @test_image_file)
+  end
+
+  defp download_images(filename, opts) do
+    base_url = opts[:base_url] || @base_url
+
+    data = Utils.get!(base_url <> filename).body
     <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
     {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
   end
 
-  defp download_labels(label_file) do
-    data = Utils.get!(@base_url <> label_file).body
+  defp download_labels(:train, opts) do
+    download_labels(opts[:train_label_file] || @train_label_file)
+  end
+
+  defp download_labels(:test, opts) do
+    download_labels(opts[:test_label_file] || @test_label_file)
+  end
+
+  defp download_labels(filename, opts) do
+    base_url = opts[:base_url] || @base_url
+
+    data = Utils.get!(base_url <> filename).body
     <<_::32, n_labels::32, labels::binary>> = data
     {labels, {:u, 8}, {n_labels}}
   end

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -52,11 +52,11 @@ defmodule Scidata.FashionMNIST do
   end
 
   defp download_images(:train, opts) do
-    download_images(opts[:train_image_file] || @train_image_file)
+    download_images(opts[:train_image_file] || @train_image_file, opts)
   end
 
   defp download_images(:test, opts) do
-    download_images(opts[:test_image_file] || @test_image_file)
+    download_images(opts[:test_image_file] || @test_image_file, opts)
   end
 
   defp download_images(filename, opts) do
@@ -68,11 +68,11 @@ defmodule Scidata.FashionMNIST do
   end
 
   defp download_labels(:train, opts) do
-    download_labels(opts[:train_label_file] || @train_label_file)
+    download_labels(opts[:train_label_file] || @train_label_file, opts)
   end
 
   defp download_labels(:test, opts) do
-    download_labels(opts[:test_label_file] || @test_label_file)
+    download_labels(opts[:test_label_file] || @test_label_file, opts)
   end
 
   defp download_labels(filename, opts) do

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -29,17 +29,17 @@ defmodule Scidata.FashionMNIST do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/"`
-    * `:train_image_file` - optional. Training set image filename.
+    * `:train_image_file` - Training set image filename.
       Defaults to `"train-images-idx3-ubyte.gz"`
-    * `:train_label_file` - optional. Training set label filename.
+    * `:train_label_file` - Training set label filename.
       Defaults to `"train-images-idx1-ubyte.gz"`
-    * `:test_image_file` - optional. Test set image filename.
+    * `:test_image_file` - Test set image filename.
       Defaults to `"test-images-idx3-ubyte.gz"`
-    * `:test_label_file` - optional. Test set label filename.
+    * `:test_label_file` - Test set label filename.
       Defaults to `"test-labels-idx1-ubyte.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -27,6 +27,19 @@ defmodule Scidata.FashionMNIST do
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/"`
+    * `:train_image_file` - optional. Training set image filename.
+      Defaults to `"train-images-idx3-ubyte.gz"`
+    * `:train_label_file` - optional. Training set label filename.
+      Defaults to `"train-images-idx1-ubyte.gz"`
+    * `:test_image_file` - optional. Test set image filename.
+      Defaults to `"test-images-idx3-ubyte.gz"`
+    * `:test_label_file` - optional. Test set label filename.
+      Defaults to `"test-labels-idx1-ubyte.gz"`
+
   ## Examples
 
       iex> Scidata.FashionMNIST.download()

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -30,16 +30,19 @@ defmodule Scidata.FashionMNIST do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/"`
+
     * `:train_image_file` - Training set image filename.
+
       Defaults to `"train-images-idx3-ubyte.gz"`
+
     * `:train_label_file` - Training set label filename.
+
       Defaults to `"train-images-idx1-ubyte.gz"`
-    * `:test_image_file` - Test set image filename.
-      Defaults to `"test-images-idx3-ubyte.gz"`
-    * `:test_label_file` - Test set label filename.
-      Defaults to `"test-labels-idx1-ubyte.gz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   ## Examples
@@ -61,6 +64,25 @@ defmodule Scidata.FashionMNIST do
 
   @doc """
   Downloads the FashionMNIST test dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - Dataset base URL.
+
+      Defaults to `"http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/"`
+
+    * `:test_image_file` - Test set image filename.
+
+      Defaults to `"t10k-images-idx3-ubyte.gz"`
+
+    * `:test_label_file` - Test set label filename.
+
+      Defaults to `"t10k-labels-idx1-ubyte.gz"`
+
+    * `:cache_dir` - Cache directory.
+
+      Defaults to `System.tmp_dir!()`
+
   """
   def download_test(opts \\ []) do
     {download_images(:test, opts), download_labels(:test, opts)}

--- a/lib/scidata/fashionmnist.ex
+++ b/lib/scidata/fashionmnist.ex
@@ -39,6 +39,8 @@ defmodule Scidata.FashionMNIST do
       Defaults to `"test-images-idx3-ubyte.gz"`
     * `:test_label_file` - optional. Test set label filename.
       Defaults to `"test-labels-idx1-ubyte.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   ## Examples
 
@@ -75,7 +77,7 @@ defmodule Scidata.FashionMNIST do
   defp download_images(filename, opts) do
     base_url = opts[:base_url] || @base_url
 
-    data = Utils.get!(base_url <> filename).body
+    data = Utils.get!(base_url <> filename, opts).body
     <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
     {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
   end
@@ -91,7 +93,7 @@ defmodule Scidata.FashionMNIST do
   defp download_labels(filename, opts) do
     base_url = opts[:base_url] || @base_url
 
-    data = Utils.get!(base_url <> filename).body
+    data = Utils.get!(base_url <> filename, opts).body
     <<_::32, n_labels::32, labels::binary>> = data
     {labels, {:u, 8}, {n_labels}}
   end

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -22,10 +22,15 @@ defmodule Scidata.IMDBReviews do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
+
     * `:dataset_file` - Dataset filename.
+
       Defaults to `"aclImdb_v1.tar.gz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   """
@@ -38,18 +43,10 @@ defmodule Scidata.IMDBReviews do
   @doc """
   Downloads the IMDB reviews test dataset or fetches it locally.
 
-  `example_types` is the same as in `download/2`, but `:unsup` is
+  `example_types` is the same as in `download/1`, but `:unsup` is
   unavailable because all unlabeled examples are in the training set.
 
-  ## Options.
-
-    * `:base_url` - Dataset base URL.
-      Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
-    * `:dataset_file` - Dataset filename.
-      Defaults to `"aclImdb_v1.tar.gz"`
-    * `:cache_dir` - Cache directory.
-      Defaults to `System.tmp_dir!()`
-
+  Accepts the same options as `download/1`.
   """
   @spec download_test(example_types: [test_sentiment]) :: %{
           review: [binary(), ...],

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -39,8 +39,10 @@ defmodule Scidata.IMDBReviews do
 
   defp download_dataset(dataset_type, opts) do
     example_types = opts[:example_types] || [:pos, :neg]
+    base_url = opts[:base_url] || @base_url
+    dataset_file = opts[:dataset_file] || @dataset_file
 
-    files = Utils.get!(@base_url <> @dataset_file).body
+    files = Utils.get!(base_url <> dataset_file).body
     regex = ~r"#{dataset_type}/(#{Enum.join(example_types, "|")})/"
 
     {inputs, labels} =

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -18,6 +18,14 @@ defmodule Scidata.IMDBReviews do
   according to each example's label: `:pos` for positive examples, `:neg` for
   negative examples, and `:unsup` for unlabeled examples. If no `example_types`
   are provided, `:pos` and `:neg` examples are fetched.
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"aclImdb_v1.tar.gz"`
+
   """
   @spec download(example_types: [train_sentiment]) :: %{
           review: [binary(), ...],
@@ -30,6 +38,14 @@ defmodule Scidata.IMDBReviews do
 
   `example_types` is the same as in `download/2`, but `:unsup` is
   unavailable because all unlabeled examples are in the training set.
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"aclImdb_v1.tar.gz"`
+
   """
   @spec download_test(example_types: [test_sentiment]) :: %{
           review: [binary(), ...],

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -25,6 +25,8 @@ defmodule Scidata.IMDBReviews do
       Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"aclImdb_v1.tar.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   @spec download(example_types: [train_sentiment]) :: %{
@@ -45,6 +47,8 @@ defmodule Scidata.IMDBReviews do
       Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"aclImdb_v1.tar.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   @spec download_test(example_types: [test_sentiment]) :: %{
@@ -58,7 +62,7 @@ defmodule Scidata.IMDBReviews do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 
-    files = Utils.get!(base_url <> dataset_file).body
+    files = Utils.get!(base_url <> dataset_file, opts).body
     regex = ~r"#{dataset_type}/(#{Enum.join(example_types, "|")})/"
 
     {inputs, labels} =

--- a/lib/scidata/imdb_reviews.ex
+++ b/lib/scidata/imdb_reviews.ex
@@ -21,11 +21,11 @@ defmodule Scidata.IMDBReviews do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"aclImdb_v1.tar.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """
@@ -43,11 +43,11 @@ defmodule Scidata.IMDBReviews do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"http://ai.stanford.edu/~amaas/data/sentiment/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"aclImdb_v1.tar.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -28,17 +28,17 @@ defmodule Scidata.KuzushijiMNIST do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"http://codh.rois.ac.jp/kmnist/dataset/kmnist/"`
-    * `:train_image_file` - optional. Training set image filename.
+    * `:train_image_file` - Training set image filename.
       Defaults to `"train-images-idx3-ubyte.gz"`
-    * `:train_label_file` - optional. Training set label filename.
+    * `:train_label_file` - Training set label filename.
       Defaults to `"train-images-idx1-ubyte.gz"`
-    * `:test_image_file` - optional. Test set image filename.
+    * `:test_image_file` - Test set image filename.
       Defaults to `"test-images-idx3-ubyte.gz"`
-    * `:test_label_file` - optional. Test set label filename.
+    * `:test_label_file` - Test set label filename.
       Defaults to `"test-labels-idx1-ubyte.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -26,6 +26,19 @@ defmodule Scidata.KuzushijiMNIST do
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"http://codh.rois.ac.jp/kmnist/dataset/kmnist/"`
+    * `:train_image_file` - optional. Training set image filename.
+      Defaults to `"train-images-idx3-ubyte.gz"`
+    * `:train_label_file` - optional. Training set label filename.
+      Defaults to `"train-images-idx1-ubyte.gz"`
+    * `:test_image_file` - optional. Test set image filename.
+      Defaults to `"test-images-idx3-ubyte.gz"`
+    * `:test_label_file` - optional. Test set label filename.
+      Defaults to `"test-labels-idx1-ubyte.gz"`
+
   """
   def download(opts \\ []) do
     {download_images(:train, opts), download_labels(:train, opts)}

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -29,16 +29,19 @@ defmodule Scidata.KuzushijiMNIST do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"http://codh.rois.ac.jp/kmnist/dataset/kmnist/"`
+
     * `:train_image_file` - Training set image filename.
+
       Defaults to `"train-images-idx3-ubyte.gz"`
+
     * `:train_label_file` - Training set label filename.
+
       Defaults to `"train-images-idx1-ubyte.gz"`
-    * `:test_image_file` - Test set image filename.
-      Defaults to `"test-images-idx3-ubyte.gz"`
-    * `:test_label_file` - Test set label filename.
-      Defaults to `"test-labels-idx1-ubyte.gz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   """
@@ -48,6 +51,25 @@ defmodule Scidata.KuzushijiMNIST do
 
   @doc """
   Downloads the Kuzushiji MNIST test dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - Dataset base URL.
+
+      Defaults to `"http://codh.rois.ac.jp/kmnist/dataset/kmnist/"`
+
+    * `:test_image_file` - Test set image filename.
+
+      Defaults to `"t10k-images-idx3-ubyte.gz"`
+
+    * `:test_label_file` - Test set label filename.
+
+      Defaults to `"t10k-labels-idx1-ubyte.gz"`
+
+    * `:cache_dir` - Cache directory.
+
+      Defaults to `System.tmp_dir!()`
+
   """
   def download_test(opts \\ []) do
     {download_images(:test, opts), download_labels(:test, opts)}

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -27,25 +27,45 @@ defmodule Scidata.KuzushijiMNIST do
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
   """
-  def download() do
-    {download_images(@train_image_file), download_labels(@train_label_file)}
+  def download(opts \\ []) do
+    {download_images(:train, opts), download_labels(:train, opts)}
   end
 
   @doc """
   Downloads the Kuzushiji MNIST test dataset or fetches it locally.
   """
-  def download_test() do
-    {download_images(@test_image_file), download_labels(@test_label_file)}
+  def download_test(opts \\ []) do
+    {download_images(:test, opts), download_labels(:test, opts)}
   end
 
-  defp download_images(image_file) do
-    data = Utils.get!(@base_url <> image_file).body
+  defp download_images(:train, opts) do
+    download_images(opts[:train_image_file] || @train_image_file)
+  end
+
+  defp download_images(:test, opts) do
+    download_images(opts[:test_image_file] || @test_image_file)
+  end
+
+  defp download_images(filename, opts) do
+    base_url = opts[:base_url] || @base_url
+
+    data = Utils.get!(base_url <> filename).body
     <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
     {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
   end
 
-  defp download_labels(label_file) do
-    data = Utils.get!(@base_url <> label_file).body
+  defp download_labels(:train, opts) do
+    download_labels(opts[:train_label_file] || @train_label_file)
+  end
+
+  defp download_labels(:test, opts) do
+    download_labels(opts[:test_label_file] || @test_label_file)
+  end
+
+  defp download_labels(filename, opts) do
+    base_url = opts[:base_url] || @base_url
+
+    data = Utils.get!(base_url <> filename).body
     <<_::32, n_labels::32, labels::binary>> = data
     {labels, {:u, 8}, {n_labels}}
   end

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -38,6 +38,8 @@ defmodule Scidata.KuzushijiMNIST do
       Defaults to `"test-images-idx3-ubyte.gz"`
     * `:test_label_file` - optional. Test set label filename.
       Defaults to `"test-labels-idx1-ubyte.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   def download(opts \\ []) do
@@ -62,7 +64,7 @@ defmodule Scidata.KuzushijiMNIST do
   defp download_images(filename, opts) do
     base_url = opts[:base_url] || @base_url
 
-    data = Utils.get!(base_url <> filename).body
+    data = Utils.get!(base_url <> filename, opts).body
     <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
     {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
   end
@@ -78,7 +80,7 @@ defmodule Scidata.KuzushijiMNIST do
   defp download_labels(filename, opts) do
     base_url = opts[:base_url] || @base_url
 
-    data = Utils.get!(base_url <> filename).body
+    data = Utils.get!(base_url <> filename, opts).body
     <<_::32, n_labels::32, labels::binary>> = data
     {labels, {:u, 8}, {n_labels}}
   end

--- a/lib/scidata/kuzushiji_mnist.ex
+++ b/lib/scidata/kuzushiji_mnist.ex
@@ -39,11 +39,11 @@ defmodule Scidata.KuzushijiMNIST do
   end
 
   defp download_images(:train, opts) do
-    download_images(opts[:train_image_file] || @train_image_file)
+    download_images(opts[:train_image_file] || @train_image_file, opts)
   end
 
   defp download_images(:test, opts) do
-    download_images(opts[:test_image_file] || @test_image_file)
+    download_images(opts[:test_image_file] || @test_image_file, opts)
   end
 
   defp download_images(filename, opts) do
@@ -55,11 +55,11 @@ defmodule Scidata.KuzushijiMNIST do
   end
 
   defp download_labels(:train, opts) do
-    download_labels(opts[:train_label_file] || @train_label_file)
+    download_labels(opts[:train_label_file] || @train_label_file, opts)
   end
 
   defp download_labels(:test, opts) do
-    download_labels(opts[:test_label_file] || @test_label_file)
+    download_labels(opts[:test_label_file] || @test_label_file, opts)
   end
 
   defp download_labels(filename, opts) do

--- a/lib/scidata/mnist.ex
+++ b/lib/scidata/mnist.ex
@@ -38,6 +38,8 @@ defmodule Scidata.MNIST do
       Defaults to `"test-images-idx3-ubyte.gz"`
     * `:test_label_file` - optional. Test set label filename.
       Defaults to `"test-labels-idx1-ubyte.gz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   def download(opts \\ []) do
@@ -62,7 +64,7 @@ defmodule Scidata.MNIST do
   defp download_images(filename, opts) do
     base_url = opts[:base_url] || @base_url
 
-    data = Utils.get!(base_url <> filename).body
+    data = Utils.get!(base_url <> filename, opts).body
     <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
     {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
   end
@@ -78,7 +80,7 @@ defmodule Scidata.MNIST do
   defp download_labels(filename, opts) do
     base_url = opts[:base_url] || @base_url
 
-    data = Utils.get!(base_url <> filename).body
+    data = Utils.get!(base_url <> filename, opts).body
     <<_::32, n_labels::32, labels::binary>> = data
     {labels, {:u, 8}, {n_labels}}
   end

--- a/lib/scidata/mnist.ex
+++ b/lib/scidata/mnist.ex
@@ -28,17 +28,17 @@ defmodule Scidata.MNIST do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://storage.googleapis.com/cvdf-datasets/mnist/"`
-    * `:train_image_file` - optional. Training set image filename.
+    * `:train_image_file` - Training set image filename.
       Defaults to `"train-images-idx3-ubyte.gz"`
-    * `:train_label_file` - optional. Training set label filename.
+    * `:train_label_file` - Training set label filename.
       Defaults to `"train-images-idx1-ubyte.gz"`
-    * `:test_image_file` - optional. Test set image filename.
+    * `:test_image_file` - Test set image filename.
       Defaults to `"test-images-idx3-ubyte.gz"`
-    * `:test_label_file` - optional. Test set label filename.
+    * `:test_label_file` - Test set label filename.
       Defaults to `"test-labels-idx1-ubyte.gz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/mnist.ex
+++ b/lib/scidata/mnist.ex
@@ -26,6 +26,19 @@ defmodule Scidata.MNIST do
       |> Nx.new_axis(-1)
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://storage.googleapis.com/cvdf-datasets/mnist/"`
+    * `:train_image_file` - optional. Training set image filename.
+      Defaults to `"train-images-idx3-ubyte.gz"`
+    * `:train_label_file` - optional. Training set label filename.
+      Defaults to `"train-images-idx1-ubyte.gz"`
+    * `:test_image_file` - optional. Test set image filename.
+      Defaults to `"test-images-idx3-ubyte.gz"`
+    * `:test_label_file` - optional. Test set label filename.
+      Defaults to `"test-labels-idx1-ubyte.gz"`
+
   """
   def download(opts \\ []) do
     {download_images(:train, opts), download_labels(:train, opts)}

--- a/lib/scidata/mnist.ex
+++ b/lib/scidata/mnist.ex
@@ -39,11 +39,11 @@ defmodule Scidata.MNIST do
   end
 
   defp download_images(:train, opts) do
-    download_images(opts[:train_image_file] || @train_image_file)
+    download_images(opts[:train_image_file] || @train_image_file, opts)
   end
 
   defp download_images(:test, opts) do
-    download_images(opts[:test_image_file] || @test_image_file)
+    download_images(opts[:test_image_file] || @test_image_file, opts)
   end
 
   defp download_images(filename, opts) do
@@ -55,11 +55,11 @@ defmodule Scidata.MNIST do
   end
 
   defp download_labels(:train, opts) do
-    download_labels(opts[:train_label_file] || @train_label_file)
+    download_labels(opts[:train_label_file] || @train_label_file, opts)
   end
 
   defp download_labels(:test, opts) do
-    download_labels(opts[:test_label_file] || @test_label_file)
+    download_labels(opts[:test_label_file] || @test_label_file, opts)
   end
 
   defp download_labels(filename, opts) do

--- a/lib/scidata/mnist.ex
+++ b/lib/scidata/mnist.ex
@@ -27,25 +27,45 @@ defmodule Scidata.MNIST do
       |> Nx.equal(Nx.tensor(Enum.to_list(0..9)))
 
   """
-  def download() do
-    {download_images(@train_image_file), download_labels(@train_label_file)}
+  def download(opts \\ []) do
+    {download_images(:train, opts), download_labels(:train, opts)}
   end
 
   @doc """
   Downloads the MNIST test dataset or fetches it locally.
   """
-  def download_test() do
-    {download_images(@test_image_file), download_labels(@test_label_file)}
+  def download_test(opts \\ []) do
+    {download_images(:test, opts), download_labels(:test, opts)}
   end
 
-  defp download_images(image_file) do
-    data = Utils.get!(@base_url <> image_file).body
+  defp download_images(:train, opts) do
+    download_images(opts[:train_image_file] || @train_image_file)
+  end
+
+  defp download_images(:test, opts) do
+    download_images(opts[:test_image_file] || @test_image_file)
+  end
+
+  defp download_images(filename, opts) do
+    base_url = opts[:base_url] || @base_url
+
+    data = Utils.get!(base_url <> filename).body
     <<_::32, n_images::32, n_rows::32, n_cols::32, images::binary>> = data
     {images, {:u, 8}, {n_images, 1, n_rows, n_cols}}
   end
 
-  defp download_labels(label_file) do
-    data = Utils.get!(@base_url <> label_file).body
+  defp download_labels(:train, opts) do
+    download_labels(opts[:train_label_file] || @train_label_file)
+  end
+
+  defp download_labels(:test, opts) do
+    download_labels(opts[:test_label_file] || @test_label_file)
+  end
+
+  defp download_labels(filename, opts) do
+    base_url = opts[:base_url] || @base_url
+
+    data = Utils.get!(base_url <> filename).body
     <<_::32, n_labels::32, labels::binary>> = data
     {labels, {:u, 8}, {n_labels}}
   end

--- a/lib/scidata/mnist.ex
+++ b/lib/scidata/mnist.ex
@@ -29,16 +29,19 @@ defmodule Scidata.MNIST do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://storage.googleapis.com/cvdf-datasets/mnist/"`
+
     * `:train_image_file` - Training set image filename.
+
       Defaults to `"train-images-idx3-ubyte.gz"`
+
     * `:train_label_file` - Training set label filename.
+
       Defaults to `"train-images-idx1-ubyte.gz"`
-    * `:test_image_file` - Test set image filename.
-      Defaults to `"test-images-idx3-ubyte.gz"`
-    * `:test_label_file` - Test set label filename.
-      Defaults to `"test-labels-idx1-ubyte.gz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   """
@@ -48,6 +51,33 @@ defmodule Scidata.MNIST do
 
   @doc """
   Downloads the MNIST test dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - Dataset base URL.
+
+      Defaults to `"https://storage.googleapis.com/cvdf-datasets/mnist/"`
+
+    * `:train_image_file` - Training set image filename.
+
+      Defaults to `"train-images-idx3-ubyte.gz"`
+
+    * `:train_label_file` - Training set label filename.
+
+      Defaults to `"train-images-idx1-ubyte.gz"`
+
+    * `:test_image_file` - Test set image filename.
+
+      Defaults to `"t10k-images-idx3-ubyte.gz"`
+
+    * `:test_label_file` - Test set label filename.
+
+      Defaults to `"t10k-labels-idx1-ubyte.gz"`
+
+    * `:cache_dir` - Cache directory.
+
+      Defaults to `System.tmp_dir!()`
+
   """
   def download_test(opts \\ []) do
     {download_images(:test, opts), download_labels(:test, opts)}

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -16,10 +16,15 @@ defmodule Scidata.Squad do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
+
     * `:train_dataset_file` - Training set filename.
+
       Defaults to `"train-v1.1.json"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   ## Examples
@@ -54,10 +59,15 @@ defmodule Scidata.Squad do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
+
     * `:test_dataset_file` - Test set filename.
+
       Defaults to `"dev-v1.1.json"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -13,6 +13,13 @@ defmodule Scidata.Squad do
   @doc """
   Downloads the SQuAD training dataset
 
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
+    * `:train_dataset_file` - optional. Training set filename.
+      Defaults to `"train-v1.1.json"`
+
   ## Examples
 
       iex> Scidata.Squad.download()
@@ -41,6 +48,13 @@ defmodule Scidata.Squad do
 
   @doc """
   Downloads the SQuAD test dataset
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
+    * `:test_dataset_file` - optional. Test set filename.
+      Defaults to `"dev-v1.1.json"`
 
   ## Examples
 

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -19,6 +19,8 @@ defmodule Scidata.Squad do
       Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
     * `:train_dataset_file` - optional. Training set filename.
       Defaults to `"train-v1.1.json"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   ## Examples
 
@@ -55,6 +57,8 @@ defmodule Scidata.Squad do
       Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
     * `:test_dataset_file` - optional. Test set filename.
       Defaults to `"dev-v1.1.json"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   ## Examples
 
@@ -88,7 +92,7 @@ defmodule Scidata.Squad do
     base_url = opts[:base_url] || @base_url
 
     content =
-      Utils.get!(base_url <> dataset_name).body
+      Utils.get!(base_url <> dataset_name, opts).body
       |> Jason.decode!()
 
     content["data"]

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -15,11 +15,11 @@ defmodule Scidata.Squad do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
-    * `:train_dataset_file` - optional. Training set filename.
+    * `:train_dataset_file` - Training set filename.
       Defaults to `"train-v1.1.json"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   ## Examples
@@ -53,11 +53,11 @@ defmodule Scidata.Squad do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://rajpurkar.github.io/SQuAD-explorer/dataset/"`
-    * `:test_dataset_file` - optional. Test set filename.
+    * `:test_dataset_file` - Test set filename.
       Defaults to `"dev-v1.1.json"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   ## Examples

--- a/lib/scidata/squad.ex
+++ b/lib/scidata/squad.ex
@@ -35,8 +35,8 @@ defmodule Scidata.Squad do
       ]
   """
 
-  def download() do
-    download_dataset(@train_dataset_file)
+  def download(opts \\ []) do
+    download_dataset(opts[:train_dataset_file] || @train_dataset_file, opts)
   end
 
   @doc """
@@ -66,13 +66,15 @@ defmodule Scidata.Squad do
       ]
   """
 
-  def download_test() do
-    download_dataset(@test_dataset_file)
+  def download_test(opts \\ []) do
+    download_dataset(opts[:test_dataset_file] || @test_dataset_file, opts)
   end
 
-  defp download_dataset(dataset_name) do
+  defp download_dataset(dataset_name, opts) do
+    base_url = opts[:base_url] || @base_url
+
     content =
-      Utils.get!(@base_url <> dataset_name).body
+      Utils.get!(base_url <> dataset_name).body
       |> Jason.decode!()
 
     content["data"]

--- a/lib/scidata/utils.ex
+++ b/lib/scidata/utils.ex
@@ -89,6 +89,7 @@ defmodule Scidata.Utils do
     uri = URI.parse(request.url)
     path = Enum.join([uri.host, String.replace(uri.path, "/", "-")], "-")
     cache_dir = opts[:cache_dir] || System.tmp_dir!()
+    File.mkdir_p!(cache_dir)
     Path.join(cache_dir, path)
   end
 end

--- a/lib/scidata/yelp_full_reviews.ex
+++ b/lib/scidata/yelp_full_reviews.ex
@@ -16,10 +16,15 @@ defmodule Scidata.YelpFullReviews do
   ## Options.
 
     * `:base_url` - Dataset base URL.
+
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
+
     * `:dataset_file` - Dataset filename.
+
       Defaults to `"yelp_review_full_csv.tgz"`
+
     * `:cache_dir` - Cache directory.
+
       Defaults to `System.tmp_dir!()`
 
   """
@@ -29,15 +34,7 @@ defmodule Scidata.YelpFullReviews do
   @doc """
   Downloads the Yelp Reviews test dataset or fetches it locally.
 
-  ## Options.
-
-    * `:base_url` - Dataset base URL.
-      Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
-    * `:dataset_file` - Dataset filename.
-      Defaults to `"yelp_review_full_csv.tgz"`
-    * `:cache_dir` - Cache directory.
-      Defaults to `System.tmp_dir!()`
-
+  Accepts the same options as `download/1`.
   """
   @spec download_test(Keyword.t()) :: %{
           review: [binary(), ...],

--- a/lib/scidata/yelp_full_reviews.ex
+++ b/lib/scidata/yelp_full_reviews.ex
@@ -19,6 +19,8 @@ defmodule Scidata.YelpFullReviews do
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"yelp_review_full_csv.tgz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   @spec download(Keyword.t()) :: %{review: [binary(), ...], rating: [5 | 4 | 3 | 2 | 1]}
@@ -33,6 +35,8 @@ defmodule Scidata.YelpFullReviews do
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"yelp_review_full_csv.tgz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   @spec download_test(Keyword.t()) :: %{
@@ -45,7 +49,7 @@ defmodule Scidata.YelpFullReviews do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 
-    files = Utils.get!(base_url <> dataset_file).body
+    files = Utils.get!(base_url <> dataset_file, opts).body
     regex = ~r"#{dataset_type}"
 
     records =

--- a/lib/scidata/yelp_full_reviews.ex
+++ b/lib/scidata/yelp_full_reviews.ex
@@ -12,12 +12,28 @@ defmodule Scidata.YelpFullReviews do
 
   @doc """
   Downloads the Yelp Reviews training dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"yelp_review_full_csv.tgz"`
+
   """
   @spec download(Keyword.t()) :: %{review: [binary(), ...], rating: [5 | 4 | 3 | 2 | 1]}
   def download(opts \\ []), do: download_dataset(:train, opts)
 
   @doc """
   Downloads the Yelp Reviews test dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"yelp_review_full_csv.tgz"`
+
   """
   @spec download_test(Keyword.t()) :: %{
           review: [binary(), ...],

--- a/lib/scidata/yelp_full_reviews.ex
+++ b/lib/scidata/yelp_full_reviews.ex
@@ -13,20 +13,23 @@ defmodule Scidata.YelpFullReviews do
   @doc """
   Downloads the Yelp Reviews training dataset or fetches it locally.
   """
-  @spec download() :: %{review: [binary(), ...], rating: [5 | 4 | 3 | 2 | 1]}
-  def download(), do: download_dataset(:train)
+  @spec download(Keyword.t()) :: %{review: [binary(), ...], rating: [5 | 4 | 3 | 2 | 1]}
+  def download(opts \\ []), do: download_dataset(:train, opts)
 
   @doc """
   Downloads the Yelp Reviews test dataset or fetches it locally.
   """
-  @spec download_test() :: %{
+  @spec download_test(Keyword.t()) :: %{
           review: [binary(), ...],
           rating: [5 | 4 | 3 | 2 | 1]
         }
-  def download_test(), do: download_dataset(:test)
+  def download_test(opts \\ []), do: download_dataset(:test, opts)
 
-  defp download_dataset(dataset_type) do
-    files = Utils.get!(@base_url <> @dataset_file).body
+  defp download_dataset(dataset_type, opts) do
+    base_url = opts[:base_url] || @base_url
+    dataset_file = opts[:dataset_file] || @dataset_file
+
+    files = Utils.get!(base_url <> dataset_file).body
     regex = ~r"#{dataset_type}"
 
     records =

--- a/lib/scidata/yelp_full_reviews.ex
+++ b/lib/scidata/yelp_full_reviews.ex
@@ -15,11 +15,11 @@ defmodule Scidata.YelpFullReviews do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"yelp_review_full_csv.tgz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """
@@ -31,11 +31,11 @@ defmodule Scidata.YelpFullReviews do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"yelp_review_full_csv.tgz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/yelp_polarity_reviews.ex
+++ b/lib/scidata/yelp_polarity_reviews.ex
@@ -13,20 +13,23 @@ defmodule Scidata.YelpPolarityReviews do
   @doc """
   Downloads the Yelp Polarity Reviews training dataset or fetches it locally.
   """
-  @spec download() :: %{review: [binary(), ...], sentiment: [1 | 0]}
-  def download(), do: download_dataset(:train)
+  @spec download(Keyword.t()) :: %{review: [binary(), ...], sentiment: [1 | 0]}
+  def download(opts \\ []), do: download_dataset(:train, opts)
 
   @doc """
   Downloads the Yelp Polarity Reviews test dataset or fetches it locally.
   """
-  @spec download_test() :: %{
+  @spec download_test(Keyword.t()) :: %{
           review: [binary(), ...],
           sentiment: [1 | 0]
         }
-  def download_test(), do: download_dataset(:test)
+  def download_test(opts \\ []), do: download_dataset(:test, opts)
 
-  defp download_dataset(dataset_type) do
-    files = Utils.get!(@base_url <> @dataset_file).body
+  defp download_dataset(dataset_type, opts) do
+    base_url = opts[:base_url] || @base_url
+    dataset_file = opts[:dataset_file] || @dataset_file
+
+    files = Utils.get!(base_url <> dataset_file).body
     regex = ~r"#{dataset_type}"
 
     records =

--- a/lib/scidata/yelp_polarity_reviews.ex
+++ b/lib/scidata/yelp_polarity_reviews.ex
@@ -15,11 +15,11 @@ defmodule Scidata.YelpPolarityReviews do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"yelp_review_polarity_csv.tgz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """
@@ -31,11 +31,11 @@ defmodule Scidata.YelpPolarityReviews do
 
   ## Options.
 
-    * `:base_url` - optional. Dataset base URL.
+    * `:base_url` - Dataset base URL.
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
-    * `:dataset_file` - optional. Dataset filename.
+    * `:dataset_file` - Dataset filename.
       Defaults to `"yelp_review_polarity_csv.tgz"`
-    * `:cache_dir` - optional. Cache directory.
+    * `:cache_dir` - Cache directory.
       Defaults to `System.tmp_dir!()`
 
   """

--- a/lib/scidata/yelp_polarity_reviews.ex
+++ b/lib/scidata/yelp_polarity_reviews.ex
@@ -29,15 +29,7 @@ defmodule Scidata.YelpPolarityReviews do
   @doc """
   Downloads the Yelp Polarity Reviews test dataset or fetches it locally.
 
-  ## Options.
-
-    * `:base_url` - Dataset base URL.
-      Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
-    * `:dataset_file` - Dataset filename.
-      Defaults to `"yelp_review_polarity_csv.tgz"`
-    * `:cache_dir` - Cache directory.
-      Defaults to `System.tmp_dir!()`
-
+  Accepts the same options as `download/1`.
   """
   @spec download_test(Keyword.t()) :: %{
           review: [binary(), ...],

--- a/lib/scidata/yelp_polarity_reviews.ex
+++ b/lib/scidata/yelp_polarity_reviews.ex
@@ -12,12 +12,28 @@ defmodule Scidata.YelpPolarityReviews do
 
   @doc """
   Downloads the Yelp Polarity Reviews training dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"yelp_review_polarity_csv.tgz"`
+
   """
   @spec download(Keyword.t()) :: %{review: [binary(), ...], sentiment: [1 | 0]}
   def download(opts \\ []), do: download_dataset(:train, opts)
 
   @doc """
   Downloads the Yelp Polarity Reviews test dataset or fetches it locally.
+
+  ## Options.
+
+    * `:base_url` - optional. Dataset base URL.
+      Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
+    * `:dataset_file` - optional. Dataset filename.
+      Defaults to `"yelp_review_polarity_csv.tgz"`
+
   """
   @spec download_test(Keyword.t()) :: %{
           review: [binary(), ...],

--- a/lib/scidata/yelp_polarity_reviews.ex
+++ b/lib/scidata/yelp_polarity_reviews.ex
@@ -19,6 +19,8 @@ defmodule Scidata.YelpPolarityReviews do
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"yelp_review_polarity_csv.tgz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   @spec download(Keyword.t()) :: %{review: [binary(), ...], sentiment: [1 | 0]}
@@ -33,6 +35,8 @@ defmodule Scidata.YelpPolarityReviews do
       Defaults to `"https://s3.amazonaws.com/fast-ai-nlp/"`
     * `:dataset_file` - optional. Dataset filename.
       Defaults to `"yelp_review_polarity_csv.tgz"`
+    * `:cache_dir` - optional. Cache directory.
+      Defaults to `System.tmp_dir!()`
 
   """
   @spec download_test(Keyword.t()) :: %{
@@ -45,7 +49,7 @@ defmodule Scidata.YelpPolarityReviews do
     base_url = opts[:base_url] || @base_url
     dataset_file = opts[:dataset_file] || @dataset_file
 
-    files = Utils.get!(base_url <> dataset_file).body
+    files = Utils.get!(base_url <> dataset_file, opts).body
     regex = ~r"#{dataset_type}"
 
     records =


### PR DESCRIPTION
Currently `:scidata` only downloads datasets from hard-coded URLs, however, sometimes those hard-coded websites could go down, and users have to either manually download and save corresponding files to the cache folder, or change the URL in `:scidata`'s source code.
<img width="1022" alt="Screenshot 2022-05-08 at 21 08 15" src="https://user-images.githubusercontent.com/89497197/167314085-27c59e91-ed02-46a8-932a-8cbcb2c219e3.png">

[archived page](https://archive.ph/02Ng8)

```
iex(1)> Scidata.CIFAR10.download()

21:15:30.243 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'

** (RuntimeError) HTTP 503 "<!doctype html>\n<html xmlns:og=\"http://opengraphprotocol.org/schema/\" xmlns:fb=\"http://www.facebook.com/2008/fbml\" lang=\"en-US\"  class=\"touch-styles\">\n  <head>\n    <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge,chrome=1\">\n    \n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n    \n    <!-- This is Squarespace. --><!-- lanternfish-point-js8m -->\n<base href=\"\">\n<meta charset=\"utf-8\" />\n<title>Toronto </title>\n<link rel=\"shortcut icon\" type=\"image/x-icon\" href=\"https://images.squarespace-cdn.com/content/v1/5c8e9a223560c34f9070706f/1598456195485-J2AH3Y47B9UI0ITMWT66/favicon.ico?format=100w\"/>\n<link rel=\"canonical\" href=\"https://web.cs.toronto.edu/news-events/news/toronto-tech-boom-new-york-times\"/>\n<meta property=\"og:site_name\" content=\"Department of Computer Science, University of Toronto\"/>\n<meta property=\"og:title\" content=\"Toronto\"/>\n<meta property=\"og:latitude\" content=\"43.65961839999999\"/>\n<meta property=\"og:longitude\" content=\"-79.39692079999999\"/>\n<meta property=\"og:locality\" content=\"\"/>\n<meta property=\"og:url\" content=\"https://web.cs.toronto.edu/news-events/news/toronto-tech-boom-new-york-times\"/>\n<meta property=\"og:type\" content=\"article\"/>\n<meta property=\"og:description\" content=\"The New York Times  profiles the growth of the technology sector in Toronto, including the key roles played by members of the Department of Computer Science community.\"/>\n<meta property=\"og:image\" content=\"http://static1.squarespace.com/static/5c8e9a223560c34f9070706f/5c8ed59224a694aa88bd2c89/6238f410d6e35d634c47f202/1647962316113/UofT85530_0305TorontoSkyline019.jpg?format=1500w\"/>\n<meta property=\"og:image:width\" content=\"1500\"/>\n<meta property=\"og:image:height\" content=\"1000\"/>\n<meta itemprop=\"name\" content=\"Toronto\"/>\n<meta itemprop=\"url\" content=\"https://web.cs.toronto.edu/news-events/news/toronto-tech-boom-new-york-times\"/>\n<meta itemprop=\"description\" content=\"The New York Times  profiles the growth of the technology sector in Toronto, including the key roles played by members of the Department of Computer Science community.\"/>\n<meta itemprop=\"thumbnailUrl\" content=\"http://static1.squarespace.com/static/5c8e9a223560c34f9070706f/5c8ed59224a694aa88bd2c89/6238f410d6e35d634c47f202/1647962316113/UofT85530_0305TorontoSkyline019.jpg?format=1500w\"/>\n<link rel=\"image_src\" href=\"http://static1.squarespace.com/static/5c8e9a223560c34f9070706f/5c8ed59224a694aa88bd2c89/6238f410d6e35d634c47f202/1647962316113/UofT85530_0305TorontoSkyline019.jpg?format=1500w\" />\n<meta itemprop=\"image\" content=\"http://static1.squarespace.com/static/5c8e9a223560c34f9070706f/5c8ed59224a694aa88bd2c89/6238f410d6e35d634c47f202/1647962316113/UofT85530_0305TorontoSkyline019.jpg?format=1500w\"/>\n<meta itemprop=\"author\" content=\"U of T News\"/>\n<meta itemprop=\"datePublished\" content=\"2022-03-22T11:12:11-0400\"/>\n<meta itemprop=\"dateModified\" content=\"2022-03-22T11:18:36-0400\"/>\n<meta itemprop=\"headline\" content=\"Toronto\"/>\n<meta itemprop=\"publisher\" content=\"Department of Computer Science, University of Toronto\"/>\n<meta name=\"twitter:title\" content=\"Toronto\"/>\n<meta name=\"twitter:image\" content=\"http://static1.squarespace.com/static/5c8e9a223560c34f9070706f/5c8ed59224a694aa88bd2c89/6238f410d6e35d634c47f202/1647962316113/UofT85530_0305TorontoSkyline019.jpg?format=1500w\"/>\n<meta name=\"twitter:url\" content=\"https://web.cs.toronto.edu/news-events/news/toronto-tech-boom-new-york-times\"/>\n<meta name=\"twitter:card\" content=\"summary\"/>\n<meta name=\"twitter:description\" content=\"The New York Times  profiles the growth of the technology sector in Toronto, including the key roles played by members of the Department of Computer Science community.\"/>\n<meta name=\"description\" content=\"The New York Times profiles the growth of the technology sector in Toronto, \nincluding the key roles played by members of the Department of Computer \nScience community.\" />\n<link rel=\"preconnect\" href=\"https://images.squarespace-cdn.com\">\n<script type=\"text/javascript\" src=\"//use.typekit.net/ik/WhQmG4e5xIhD2s2Be7yvGea3coDHZSIayFyfJBfheKvfeCtIfFHN4UJLFRbh52jhWDmR5e9ojQJkwD9hwewDFejow2S3" <> ...
    (scidata 0.1.7) lib/scidata/utils.ex:51: Scidata.Utils.raise_errors/1
    (scidata 0.1.7) lib/scidata/utils.ex:13: Scidata.Utils.get!/1
    (scidata 0.1.7) lib/scidata/cifar10.ex:71: Scidata.CIFAR10.download_dataset/2
    iex:1: (file)
```
